### PR TITLE
Fixed a defaulted value for a new create_and_validate function

### DIFF
--- a/rke_tests/common.py
+++ b/rke_tests/common.py
@@ -3,7 +3,7 @@ import time
 
 def create_and_validate(
     cloud_provider, rke_client, kubectl, rke_template, nodes,
-    base_namespace=None, network_validation=None, dns_validation=None,
+    base_namespace="ns", network_validation=None, dns_validation=None,
         teardown=False, remove_nodes=False):
 
     create_rke_cluster(rke_client, kubectl, nodes, rke_template)


### PR DESCRIPTION
This should be defaulted to a lowercase string, uppercase is not allowed for namespaces, and python object None becomes "None" str with an uppercase when converted to string