### PR TITLE
Add workflow for upgrade tests

### DIFF
--- a/tests/v3_api/common.py
+++ b/tests/v3_api/common.py
@@ -107,16 +107,18 @@ def random_name():
     return "test" + "-" + str(random_int(10000, 99999))
 
 
-def create_project_and_ns(token, cluster):
+def create_project_and_ns(token, cluster, project_name=None, ns_name=None):
     client = get_client_for_token(token)
-    p = create_project(client, cluster)
+    p = create_project(client, cluster, project_name)
     c_client = get_cluster_client_for_token(cluster, token)
-    ns = create_ns(c_client, cluster, p)
+    ns = create_ns(c_client, cluster, p, ns_name)
     return p, ns
 
 
-def create_project(client, cluster):
-    p = client.create_project(name=random_name(),
+def create_project(client, cluster, project_name=None):
+    if project_name is None:
+        project_name = random_name()
+    p = client.create_project(name=project_name,
                               clusterId=cluster.id)
     p = client.wait_success(p)
     assert p.state == 'active'
@@ -138,8 +140,10 @@ def set_pspt_for_project(project, client, pspt):
     return project
 
 
-def create_ns(client, cluster, project):
-    ns = client.create_namespace(name=random_name(),
+def create_ns(client, cluster, project, ns_name=None):
+    if ns_name is None:
+        ns_name = random_name()
+    ns = client.create_namespace(name=ns_name,
                                  clusterId=cluster.id,
                                  projectId=project.id)
     # ns = wait_state(client, ns, "state", "active")

--- a/tests/v3_api/test_secrets.py
+++ b/tests/v3_api/test_secrets.py
@@ -253,8 +253,10 @@ def delete_secret(client, secret, ns, keyvaluepair):
 
 
 def create_and_validate_workload_with_secret_as_volume(p_client, secret, ns,
-                                                       keyvaluepair):
-    name = random_test_name("test")
+                                                       keyvaluepair,
+                                                       name=None):
+    if name is None:
+        name = random_test_name("test")
     # Create Workload with secret as volume
     mountpath = "/test"
     volumeMounts = [{"readOnly": False, "type": "volumeMount",
@@ -281,8 +283,10 @@ def create_and_validate_workload_with_secret_as_volume(p_client, secret, ns,
 
 
 def create_and_validate_workload_with_secret_as_env_variable(p_client, secret,
-                                                             ns, keyvaluepair):
-    name = random_test_name("test")
+                                                             ns, keyvaluepair,
+                                                             name=None):
+    if name is None:
+        name = random_test_name("test")
 
     # Create Workload with secret as env variable
     secretName = secret['name']
@@ -305,11 +309,16 @@ def create_and_validate_workload_with_secret_as_env_variable(p_client, secret,
     return workload
 
 
-def create_secret(keyvaluepair, singlenamespace=False):
+def create_secret(keyvaluepair, singlenamespace=False,
+                  p_client=None, ns=None, name=None):
 
-    p_client = namespace["p_client"]
-    name = random_test_name("default")
-    ns = namespace["ns"]
+    if p_client is None:
+        p_client = namespace["p_client"]
+
+    if name is None:
+        name = random_test_name("default")
+    if ns is None:
+        ns = namespace["ns"]
 
     if not singlenamespace:
         secret = p_client.create_secret(name=name, namespaceId='NULL',

--- a/tests/v3_api/test_service_discovery.py
+++ b/tests/v3_api/test_service_discovery.py
@@ -116,15 +116,19 @@ def test_dns_record_type_selector():
     create_and_validate_dns_record(record, expected_ips)
 
 
-def create_and_validate_dns_record(record, expected):
-    testclient_pods = namespace["testclient_pods"]
-    create_dns_record(record)
+def create_and_validate_dns_record(record, expected, p_client=None,
+                                   testclient_pods=None):
+    if testclient_pods is None:
+        testclient_pods = namespace["testclient_pods"]
+    create_dns_record(record, p_client)
+    assert len(testclient_pods) > 0
     for pod in testclient_pods:
         validate_dns_record(pod, record, expected)
 
 
-def create_dns_record(record):
-    p_client = namespace["p_client"]
+def create_dns_record(record, p_client=None):
+    if p_client is None:
+        p_client = namespace["p_client"]
     created_record = p_client.create_dns_record(record)
 
     wait_for_condition(

--- a/tests/v3_api/test_upgrade.py
+++ b/tests/v3_api/test_upgrade.py
@@ -1,0 +1,305 @@
+from common import *   # NOQA
+from test_service_discovery import create_dns_record
+from test_secrets import create_secret
+from test_secrets import create_and_validate_workload_with_secret_as_volume
+from test_secrets \
+    import create_and_validate_workload_with_secret_as_env_variable
+import pytest
+import base64
+
+cluster_name = os.environ.get('RANCHER_CLUSTER_NAME', "http://localhost:80")
+validate_prefix = os.environ.get('RANCHER_VALIDATE_RESOURCES_PREFIX', "step0")
+create_prefix = os.environ.get('RANCHER_CREATE_RESOURCES_PREFIX', "step1")
+namespace = {"p_client": None, "ns": None, "cluster": None, "project": None,
+             "testclient_pods": []}
+upgrade_check_stage = os.environ.get('RANCHER_UPGRADE_CHECK', "preupgrade")
+
+wl_name = create_prefix + "-testwl"
+sd_name = create_prefix + "-testsd"
+sd_wlname1 = create_prefix + "-testsd1"
+sd_wlname2 = create_prefix + "-testsd2"
+ingress_name = create_prefix + "-testingress"
+ingress_wlname = create_prefix + "-testingresswl"
+
+wl_name_validate = validate_prefix + "-testwl"
+sd_name_validate = validate_prefix + "-testsd"
+sd_wlname1_validate = validate_prefix + "-testsd1"
+sd_wlname2_validate = validate_prefix + "-testsd2"
+ingress_name_validate = validate_prefix + "-testingress"
+ingress_wlname_validate = validate_prefix + "-testingresswl"
+
+if_post_upgrade = pytest.mark.skipif(
+    upgrade_check_stage != "postupgrade",
+    reason='This test is not executed for PreUpgrade checks')
+
+
+def test_upgrade_create_and_validate_resources():
+    if upgrade_check_stage == "preupgrade":
+        create_and_validate_wl()
+        create_and_validate_service_discovery()
+        create_wokloads_with_secret()
+        create_and_validate_ingress_xip_io()
+
+
+@if_post_upgrade
+def test_upgrade_validate_resources():
+    # Validate existing resources
+    validate_wl(wl_name_validate)
+    validate_service_discovery(sd_name_validate,
+                               [sd_wlname1_validate, sd_wlname2_validate])
+    validate_ingress_xip_io(ingress_name_validate,
+                            ingress_wlname_validate)
+
+    # Create and validate new resources
+    create_project_resources()
+    create_and_validate_wl()
+    create_and_validate_service_discovery()
+    create_wokloads_with_secret()
+    create_and_validate_ingress_xip_io()
+
+
+def create_and_validate_wl():
+    p_client = namespace["p_client"]
+    ns = namespace["ns"]
+    con = [{"name": "test1",
+            "image": TEST_TARGET_IMAGE}]
+    p_client.create_workload(name=wl_name, containers=con,
+                             namespaceId=ns.id, scale=2)
+    validate_wl(wl_name)
+
+
+def validate_wl(workload_name):
+    p_client = namespace["p_client"]
+    ns = namespace["ns"]
+    workloads = p_client.list_workload(name=workload_name,
+                                       namespaceId=ns.id)
+    assert len(workloads) == 1
+    workload = workloads[0]
+    validate_workload(p_client, workload, "deployment", ns.name, pod_count=2)
+    validate_service_discovery(workload_name, [workload_name])
+
+
+def create_and_validate_ingress_xip_io():
+    p_client = namespace["p_client"]
+    ns = namespace["ns"]
+    cluster = namespace["cluster"]
+    con = [{"name": "test1",
+            "image": TEST_TARGET_IMAGE}]
+    workload = p_client.create_workload(name=ingress_wlname,
+                                        containers=con,
+                                        namespaceId=ns.id,
+                                        daemonSetConfig={})
+    validate_workload(p_client, workload, "daemonSet", ns.name,
+                      len(get_schedulable_nodes(cluster)))
+    path = "/name.html"
+    rule = {"host": "xip.io",
+            "paths":
+                {path: {"workloadIds": [workload.id], "targetPort": "80"}}}
+    p_client.create_ingress(name=ingress_name,
+                            namespaceId=ns.id,
+                            rules=[rule])
+    validate_ingress_xip_io(ingress_name, ingress_wlname)
+
+
+def validate_ingress_xip_io(ing_name, workload_name):
+    p_client = namespace["p_client"]
+    ns = namespace["ns"]
+    workloads = p_client.list_workload(name=workload_name,
+                                       namespaceId=ns.id)
+    assert len(workloads) == 1
+    workload = workloads[0]
+    ingresses = p_client.list_ingress(name=ing_name,
+                                      namespaceId=ns.id)
+    assert len(ingresses) == 1
+    ingress = ingresses[0]
+
+    validate_ingress_using_endpoint(p_client, ingress, [workload])
+
+
+def create_and_validate_service_discovery():
+    p_client = namespace["p_client"]
+    ns = namespace["ns"]
+    cluster = namespace["cluster"]
+
+    con = [{"name": "test1",
+            "image": TEST_TARGET_IMAGE}]
+    workload = p_client.create_workload(name=sd_wlname1,
+                                        containers=con,
+                                        namespaceId=ns.id,
+                                        daemonSetConfig={})
+    validate_workload(p_client, workload, "daemonSet", ns.name,
+                      len(get_schedulable_nodes(cluster)))
+
+    additional_workload = p_client.create_workload(name=sd_wlname2,
+                                                   containers=con,
+                                                   namespaceId=ns.id,
+                                                   scale=1)
+    wait_for_wl_to_active(p_client, additional_workload)
+    awl_pods = wait_for_pods_in_workload(p_client, additional_workload, 1)
+    wait_for_pod_to_running(p_client, awl_pods[0])
+
+    record = {"type": "dnsRecord",
+              "targetWorkloadIds": [workload["id"], additional_workload["id"]],
+              "name": sd_name,
+              "namespaceId": ns.id}
+
+    create_dns_record(record, p_client)
+    validate_service_discovery(sd_name, [sd_wlname1, sd_wlname2])
+
+
+def validate_service_discovery(sd_record_name, workload_names):
+    p_client = namespace["p_client"]
+    ns = namespace["ns"]
+    target_wls = []
+    for wl_name in workload_names:
+        workloads = p_client.list_workload(name=wl_name, namespaceId=ns.id)
+        assert len(workloads) == 1
+        workload = workloads[0]
+        target_wls.append(workload)
+
+    records = p_client.list_dns_record(name=sd_record_name, namespaceId=ns.id)
+    assert len(records) == 1
+    record = records[0]
+
+    testclient_pods = namespace["testclient_pods"]
+    expected_ips = []
+    for wl in target_wls:
+        pods = p_client.list_pod(workloadId=wl["id"])
+        for pod in pods:
+            expected_ips.append(pod["status"]["podIp"])
+
+    assert len(testclient_pods) > 0
+    for pod in testclient_pods:
+        validate_dns_record(pod, record, expected_ips)
+
+
+def create_wokloads_with_secret():
+    value = base64.b64encode("valueall")
+    keyvaluepair = {"testall": value}
+
+    p_client = namespace["p_client"]
+    ns = namespace["ns"]
+
+    secret_name = create_prefix + "-testsecret"
+    wl_name1 = create_prefix + "-testwl1withsec"
+    wl_name2 = create_prefix + "-testwl2withsec"
+
+    secret = create_secret(keyvaluepair, p_client=p_client, name=secret_name)
+    create_and_validate_workload_with_secret_as_volume(p_client,
+                                                       secret,
+                                                       ns,
+                                                       keyvaluepair,
+                                                       name=wl_name1)
+    create_and_validate_workload_with_secret_as_env_variable(p_client,
+                                                             secret,
+                                                             ns,
+                                                             keyvaluepair,
+                                                             wl_name2)
+
+
+@pytest.fixture(scope='module', autouse="True")
+def create_project_client(request):
+    client = get_admin_client()
+    clusters = client.list_cluster(name=cluster_name)
+    assert len(clusters) == 1
+    cluster = clusters[0]
+    create_kubeconfig(cluster)
+    namespace["cluster"] = cluster
+
+    if upgrade_check_stage == "preupgrade":
+        create_project_resources()
+    else:
+        validate_existing_project_resources()
+
+
+def create_project_resources():
+    cluster = namespace["cluster"]
+    p, ns = create_project_and_ns(ADMIN_TOKEN, cluster,
+                                  project_name=create_prefix + "-p1",
+                                  ns_name=create_prefix + "-ns1")
+    p_client = get_project_client_for_token(p, ADMIN_TOKEN)
+
+    namespace["p_client"] = p_client
+    namespace["ns"] = ns
+    namespace["project"] = p
+    namespace["testclient_pods"] = []
+
+    # Create pods in existing namespace and new namespace that will be used
+    # as test clients from which DNS resolution will be tested
+
+    wlname = create_prefix + "-testsdclient"
+
+    con = [{"name": "test1",
+            "image": TEST_CLIENT_IMAGE}]
+
+    workload = p_client.create_workload(name=wlname,
+                                        containers=con,
+                                        namespaceId=ns.id,
+                                        scale=1)
+    wait_for_wl_to_active(p_client, workload)
+    namespace["workload"] = workload
+
+    pods = wait_for_pods_in_workload(p_client, workload, 1)
+    pod = wait_for_pod_to_running(p_client, pods[0])
+    namespace["testclient_pods"].append(pod)
+
+    new_ns = create_ns(get_cluster_client_for_token(cluster, ADMIN_TOKEN),
+                       cluster, p, ns_name=create_prefix + "-ns2")
+
+    workload = p_client.create_workload(name=wlname,
+                                        containers=con,
+                                        namespaceId=new_ns.id,
+                                        scale=1)
+    wait_for_wl_to_active(p_client, workload)
+    pods = wait_for_pods_in_workload(p_client, workload, 1)
+    pod = wait_for_pod_to_running(p_client, pods[0])
+    namespace["testclient_pods"].append(pod)
+    assert len(namespace["testclient_pods"]) == 2
+
+
+def validate_existing_project_resources():
+    cluster = namespace["cluster"]
+    project_name = validate_prefix + "p1"
+    ns_name = validate_prefix + "-ns1"
+    ns2_name = validate_prefix + "-ns2"
+
+    # Get existing project
+    client = get_admin_client()
+    projects = client.list_project(name=project_name,
+                                   clusterId=cluster.id)
+    assert len(projects) == 1
+    project = projects[0]
+
+    c_client = get_cluster_client_for_token(cluster, ADMIN_TOKEN)
+    p_client = get_project_client_for_token(project, ADMIN_TOKEN)
+
+    # Get existing namespace
+    nss = c_client.list_namespace(name=ns_name)
+    assert len(nss) == 1
+    ns = nss[0]
+
+    # 2nd namespace
+    nss = c_client.list_namespace(name=ns2_name)
+    assert len(nss) == 1
+    ns2 = nss[0]
+
+    # Get existing SD client pods
+    workload_name = validate_prefix + "-testsdclient"
+    workloads = p_client.list_workload(name=workload_name,
+                                       namespaceId=ns.id)
+    assert len(workloads) == 1
+    wl1_pods = p_client.list_pod(workloadId=workloads[0].id)
+    assert len(wl1_pods) == 1
+
+    workload_name = validate_prefix + "-testsdclient"
+
+    workloads = p_client.list_workload(name=workload_name,
+                                       namespaceId=ns2.id)
+    assert len(workloads) == 1
+    wl2_pods = p_client.list_pod(workloadId=workloads[0].id)
+    assert len(wl2_pods) == 1
+
+    namespace["p_client"] = p_client
+    namespace["ns"] = ns
+    namespace["project"] = project
+    namespace["testclient_pods"] = [wl1_pods[0], wl2_pods[0]]


### PR DESCRIPTION
@bmdepesa @soumyalj , Can you review this PR ?
Following is the workflow that have been automated for aiding with upgrade checks done during rancher-server upgrade testing:

Pre Upgrade (RANCHER_UPGRADE_CHECK - preupgrade):
Note — All resources get created with "create prefix” prepended (RANCHER_CREATE_RESOURCES_PREFIX)

Create a Project with 2 namespaces
Namespace1:
Test Client Workload (to check SD resolution)
Namespace2:
Test Client Workload (to check SD resolution)

Checks:
Workload - Create 1 workload in Namespace1. Validate workload scale and SD resolution works for workload name from testclient workloads in Namespace1 and Namespace2.
SD - Create 2 workloads in Namespace1. Create SD pointing to these 2 workloads. Validate SD resolution works for workload name from testclient workloads in Namespace1 and Namespace2.
Ingress - Create 1 workloads in Namespace1. Create Ingress (xip.io) pointing to this workload. Validate Ingress.
Secrets - Create Secret. Deploy workload with this secret . Validate secrets are accessible from workload as env variables and secrets.


Post Upgrade (RANCHER_UPGRADE_CHECK - postupgrade):
Note — All resources get created with "create prefix” prepended (RANCHER_CREATE_RESOURCES_PREFIX)
All resources that need to be validated are looked with “validate prefix” prepended.
(RANCHER_VALIDATE_RESOURCES_PREFIX)

Validate following resources created in Preupgrade:
Workload 
SD
Ingress
Secrets —> Validation Not done yet.
Create and validate all resources mentioned in Pre upgrade step.


Names of the resources created:
project_name = create or validate prefix + “-p1"
ns1_name = create or validate prefix + “-ns1"
ns2_name  = create or validate prefix + “-ns2"
wl_name = create or validate prefix + "-testwl"
sd_name =  create or validate prefix + "-testsd"
sd_wlname1 = create or validate prefix + "-testsd1"
sd_wlname2 = create or validate prefix + "-testsd2"
ingress_name = create or validate prefix + "-testingress"
ingress_wlname = create or validate prefix + "-testingresswl"
