### PR TITLE
Ability to store cluster name in config files when cluster is not cleaned up

### DIFF
--- a/tests/v3_api/test_ad_custom_filter.py
+++ b/tests/v3_api/test_ad_custom_filter.py
@@ -9,19 +9,23 @@ Prerequisite:
 Enable AD without TLS, and using testuser1 as admin user.
 
 Description:
-In this test, we are testing the customized user and group search filter functionalities.
+In this test, we are testing the customized user and group search filter
+functionalities.
 1) For customized user search filter:
-The filter looks like: 
-(&(objectClass=person)(|(sAMAccountName=test*)(sn=test*)(givenName=test*))[user customized filter])
-Here, after we add userSearchFilter = (memberOf=CN=testgroup5,CN=Users,DC=tad,DC=rancher,DC=io)
-we will filter out only testuser40 and testuser41, otherwise, all users start with search keyword "testuser"
-will be listed out.
+The filter looks like:
+(&(objectClass=person)(|(sAMAccountName=test*)(sn=test*)(givenName=test*))
+[user customized filter])
+Here, after we add
+userSearchFilter = (memberOf=CN=testgroup5,CN=Users,DC=tad,DC=rancher,DC=io)
+we will filter out only testuser40 and testuser41, otherwise, all users start
+with search keyword "testuser" will be listed out.
 
 2) For customized group search filter:
-The filter looks like: 
+The filter looks like:
 (&(objectClass=group)(sAMAccountName=test)[group customized filter])
 Here, after we add groupSearchFilter = (cn=testgroup2)
-we will filter out only testgroup2, otherwise, all groups has search keyword "testgroup" will be listed out.
+we will filter out only testgroup2, otherwise, all groups has search
+keyword "testgroup" will be listed out.
 '''
 
 # Config Fields
@@ -53,7 +57,9 @@ CATTLE_AUTH_DISABLE_URL = CATTLE_AUTH_PROVIDER_URL + "?action=disable"
 def test_custom_user_and_group_filter_for_AD():
     disable_ad("testuser1", ADMIN_TOKEN)
     enable_ad_with_customized_filter(
-        "testuser1", "(memberOf=CN=testgroup5,CN=Users,DC=tad,DC=rancher,DC=io)", "", ADMIN_TOKEN)
+        "testuser1",
+        "(memberOf=CN=testgroup5,CN=Users,DC=tad,DC=rancher,DC=io)",
+        "", ADMIN_TOKEN)
     search_ad_users("testuser", ADMIN_TOKEN)
 
     disable_ad("testuser1", ADMIN_TOKEN)
@@ -74,7 +80,9 @@ def disable_ad(username, token, expected_status=200):
           username + " " + str(expected_status))
 
 
-def enable_ad_with_customized_filter(username, usersearchfilter, groupsearchfilter, token, expected_status=200):
+def enable_ad_with_customized_filter(username, usersearchfilter,
+                                     groupsearchfilter, token,
+                                     expected_status=200):
     headers = {'Authorization': 'Bearer ' + token}
     activeDirectoryConfig = {
         "accessMode": "unrestricted",
@@ -129,10 +137,14 @@ def search_ad_users(searchkey, token, expected_status=200):
         print(data)
         assert len(data) == 2
         print(data)
-        assert data[0].get(
-            'id') == "activedirectory_user://CN=test user40,CN=Users,DC=tad,DC=rancher,DC=io"
-        assert data[1].get(
-            'id') == "activedirectory_user://CN=test user41,CN=Users,DC=tad,DC=rancher,DC=io"
+        assert \
+            data[0].get('id') == \
+            "activedirectory_user://CN=test user40," \
+            "CN=Users,DC=tad,DC=rancher,DC=io"
+        assert \
+            data[1].get('id') == \
+            "activedirectory_user://CN=test user41," \
+            "CN=Users,DC=tad,DC=rancher,DC=io"
 
 
 def search_ad_groups(searchkey, token, expected_status=200):
@@ -146,5 +158,7 @@ def search_ad_groups(searchkey, token, expected_status=200):
     if r.status_code == 200:
         data = r.json()['data']
         assert len(data) == 1
-        assert data[0].get(
-            'id') == "activedirectory_group://CN=testgroup2,CN=Users,DC=tad,DC=rancher,DC=io"
+        assert \
+            data[0].get('id') == \
+            "activedirectory_group://CN=testgroup2," \
+            "CN=Users,DC=tad,DC=rancher,DC=io"

--- a/tests/v3_api/test_aks_cluster.py
+++ b/tests/v3_api/test_aks_cluster.py
@@ -2,7 +2,6 @@ from .common import *   # NOQA
 import pytest
 import requests
 
-RANCHER_CLEANUP_CLUSTER = os.environ.get('RANCHER_CLEANUP_CLUSTER', "True")
 AKS_CLUSTER_VERSION = os.environ.get('RANCHER_AKS_CLUSTER_VERSION', '1.11.2')
 SSH_KEY = os.environ.get('RANCHER_SSH_KEY', "")
 SUBSCRIPTION_ID = os.environ.get('RANCHER_AKS_SUBSCRIPTION_ID', '')
@@ -27,9 +26,7 @@ def test_create_aks_cluster():
     cluster = client.create_cluster(aksConfig)
     cluster = validate_cluster(client, cluster, check_intermediate_state=True,
                                skipIngresscheck=True)
-
-    if RANCHER_CLEANUP_CLUSTER == "True":
-        delete_cluster(client, cluster)
+    cluster_cleanup(client, cluster)
 
 
 def get_aks_version():

--- a/tests/v3_api/test_auth.py
+++ b/tests/v3_api/test_auth.py
@@ -24,8 +24,10 @@ USER_SEARCH_BASE = os.environ.get("RANCHER_USER_SEARCH_BASE")
 GROUP_SEARCH_BASE = os.environ.get("RANCHER_GROUP_SEARCH_BASE")
 PASSWORD = os.environ.get('RANCHER_USER_PASSWORD', "")
 AD_SPECIAL_CHAR_PASSWORD = os.environ.get("RANCHER_AD_SPECIAL_CHAR_PASSWORD")
-OPENLDAP_SPECIAL_CHAR_PASSWORD = os.environ.get("RANCHER_OPENLDAP_SPECIAL_CHAR_PASSWORD")
-FREEIPA_SPECIAL_CHAR_PASSWORD = os.environ.get("RANCHER_FREEIPA_SPECIAL_CHAR_PASSWORD")
+OPENLDAP_SPECIAL_CHAR_PASSWORD = \
+    os.environ.get("RANCHER_OPENLDAP_SPECIAL_CHAR_PASSWORD")
+FREEIPA_SPECIAL_CHAR_PASSWORD = \
+    os.environ.get("RANCHER_FREEIPA_SPECIAL_CHAR_PASSWORD")
 
 
 CATTLE_AUTH_URL = \
@@ -160,8 +162,10 @@ def special_character_users_login(access_mode):
         for group in auth_setup_data["specialchar_in_groupname"]:
             allowed_principal_ids.append(principal_lookup(group, admin_token))
 
-        allowed_principal_ids.append(principal_lookup(admin_user, admin_token))
-        add_users_to_siteAccess(admin_token, access_mode, allowed_principal_ids)
+        allowed_principal_ids.append(
+            principal_lookup(admin_user, admin_token))
+        add_users_to_siteAccess(
+            admin_token, access_mode, allowed_principal_ids)
 
         for user in auth_setup_data["specialchar_in_username"]:
             login(user, PASSWORD)
@@ -184,10 +188,11 @@ def special_character_users_login(access_mode):
             allowed_principal_ids.append(principal_lookup(group, admin_token))
 
         allowed_principal_ids.append(principal_lookup(admin_user, admin_token))
-        add_users_to_siteAccess(admin_token, access_mode, allowed_principal_ids)
+        add_users_to_siteAccess(
+            admin_token, access_mode, allowed_principal_ids)
 
         for user in auth_setup_data["specialchar_in_user_cn_sn"]:
-            login(user,PASSWORD)
+            login(user, PASSWORD)
         for user in auth_setup_data["specialchar_in_uid"]:
             login(user, PASSWORD)
         for user in auth_setup_data["specialchar_in_password"]:
@@ -204,11 +209,13 @@ def special_character_users_login(access_mode):
         for group in auth_setup_data["specialchar_in_groupname"]:
             allowed_principal_ids.append(principal_lookup(group, admin_token))
 
-        allowed_principal_ids.append(principal_lookup(admin_user, admin_token))
-        add_users_to_siteAccess(admin_token, access_mode, allowed_principal_ids)
+        allowed_principal_ids.append(
+            principal_lookup(admin_user, admin_token))
+        add_users_to_siteAccess(
+            admin_token, access_mode, allowed_principal_ids)
 
         for user in auth_setup_data["specialchar_in_users"]:
-            login(user,PASSWORD)
+            login(user, PASSWORD)
         for user in auth_setup_data["specialchar_in_password"]:
             login(user, FREEIPA_SPECIAL_CHAR_PASSWORD)
         for group in auth_setup_data["specialchar_in_groupname"]:
@@ -381,7 +388,8 @@ def validate_access_control_disable_and_enable_auth(access_mode):
         disable_freeipa(admin_user, admin_token)
         enable_freeipa(admin_user, admin_token)
 
-    # Login as users within allowed principal id list, which cannot perform disable action.
+    # Login as users within allowed principal id list, which cannot perform
+    # disable action.
     allowed_principal_ids = []
     for user in auth_setup_data["allowed_users"]:
         allowed_principal_ids.append(principal_lookup(user, admin_token))
@@ -393,14 +401,20 @@ def validate_access_control_disable_and_enable_auth(access_mode):
     for user in auth_setup_data["allowed_users"]:
         token = login(user, PASSWORD)
         if AUTH_PROVIDER == "activeDirectory":
-            disable_ad(user, token, expected_status=setup["permission_denied_code"])
-            enable_ad(user, token, expected_status=setup["permission_denied_code"])
+            disable_ad(user, token,
+                       expected_status=setup["permission_denied_code"])
+            enable_ad(user, token,
+                      expected_status=setup["permission_denied_code"])
         if AUTH_PROVIDER == "openLdap":
-            disable_openldap(user, token, expected_status=setup["permission_denied_code"])
-            enable_openldap(user, token, expected_status=setup["permission_denied_code"])
+            disable_openldap(user, token,
+                             expected_status=setup["permission_denied_code"])
+            enable_openldap(user, token,
+                            expected_status=setup["permission_denied_code"])
         if AUTH_PROVIDER == "freeIpa":
-            disable_freeipa(user, token, expected_status=setup["permission_denied_code"])
-            enable_freeipa(user, token, expected_status=setup["permission_denied_code"])
+            disable_freeipa(user, token,
+                            expected_status=setup["permission_denied_code"])
+            enable_freeipa(user, token,
+                           expected_status=setup["permission_denied_code"])
 
 
 def validate_access_control_disable_and_enable_nestedgroups(access_mode):
@@ -436,9 +450,11 @@ def validate_access_control_disable_and_enable_nestedgroups(access_mode):
 
     if AUTH_PROVIDER == "activeDirectory" or AUTH_PROVIDER == "openLdap":
         for user in auth_setup_data["users_under_nestedgroups"]:
-            login(user, PASSWORD, expected_status=setup["permission_denied_code"])
+            login(user, PASSWORD,
+                  expected_status=setup["permission_denied_code"])
 
-        # Enable nestedgroup feature, so users under nestedgroups can login successfully
+        # Enable nestedgroup feature, so users under nestedgroups can login
+        # successfully
         if AUTH_PROVIDER == "activeDirectory":
             enable_ad_nestedgroups(admin_user, token)
         if AUTH_PROVIDER == "openLdap":
@@ -446,7 +462,7 @@ def validate_access_control_disable_and_enable_nestedgroups(access_mode):
 
         allowed_principal_ids = []
         for group in auth_setup_data["allowed_nestedgroups"]:
-           allowed_principal_ids.append(principal_lookup(group, token))
+            allowed_principal_ids.append(principal_lookup(group, token))
         allowed_principal_ids.append(principal_lookup(admin_user, token))
 
         # Add users in allowed list to access rancher-server
@@ -497,9 +513,7 @@ def enable_openldap(username, token, expected_status=200):
         "nestedGroupMembershipEnabled": False,
         "enabled": True,
         "port": PORT,
-        "servers": [
-          HOSTNAME_OR_IP_ADDRESS
-        ],
+        "servers": [HOSTNAME_OR_IP_ADDRESS],
         "serviceAccountDistinguishedName": SERVICE_ACCOUNT_NAME,
         "tls": get_tls(CA_CERTIFICATE),
         "userDisabledBitMask": 0,
@@ -515,13 +529,15 @@ def enable_openldap(username, token, expected_status=200):
     ca_cert = ldapConfig["certificate"]
     ldapConfig["certificate"] = ca_cert.replace('\\n', '\n')
 
-    r = requests.post(CATTLE_AUTH_ENABLE_URL, json={
-      "ldapConfig": ldapConfig,
-      "username": username,
-      "password": PASSWORD
-    }, verify=False, headers=headers)
+    r = requests.post(CATTLE_AUTH_ENABLE_URL,
+                      json={
+                          "ldapConfig": ldapConfig,
+                          "username": username,
+                          "password": PASSWORD},
+                      verify=False, headers=headers)
     assert r.status_code == expected_status
-    print("Enable openLdap request for " + username + " " + str(expected_status))
+    print("Enable openLdap request for " +
+          username + " " + str(expected_status))
 
 
 def disable_openldap(username, token, expected_status=200):
@@ -531,7 +547,8 @@ def disable_openldap(username, token, expected_status=200):
         'password': PASSWORD
     }, verify=False, headers=headers)
     assert r.status_code == expected_status
-    print("Disable openLdap request for " + username + " " + str(expected_status))
+    print("Disable openLdap request for " +
+          username + " " + str(expected_status))
 
 
 def enable_openldap_nestedgroup(username, token, expected_status=200):
@@ -549,9 +566,7 @@ def enable_openldap_nestedgroup(username, token, expected_status=200):
         "nestedGroupMembershipEnabled": True,
         "enabled": True,
         "port": PORT,
-        "servers": [
-          HOSTNAME_OR_IP_ADDRESS
-        ],
+        "servers": [HOSTNAME_OR_IP_ADDRESS],
         "serviceAccountDistinguishedName": SERVICE_ACCOUNT_NAME,
         "tls": get_tls(CA_CERTIFICATE),
         "userDisabledBitMask": 0,
@@ -567,110 +582,111 @@ def enable_openldap_nestedgroup(username, token, expected_status=200):
     ca_cert = ldapConfig["certificate"]
     ldapConfig["certificate"] = ca_cert.replace('\\n', '\n')
 
-    r = requests.post(CATTLE_AUTH_ENABLE_URL, json={
-      "ldapConfig": ldapConfig,
-      "username": username,
-      "password": PASSWORD
-    }, verify=False, headers=headers)
+    r = requests.post(CATTLE_AUTH_ENABLE_URL,
+                      json={"ldapConfig": ldapConfig,
+                            "username": username,
+                            "password": PASSWORD},
+                      verify=False, headers=headers)
     assert r.status_code == expected_status
-    print("Enable openLdap nestedgroup request for " + username + " " + str(expected_status))
+    print("Enable openLdap nestedgroup request for " +
+          username + " " + str(expected_status))
 
 
 def enable_ad(username, token, expected_status=200):
     headers = {'Authorization': 'Bearer ' + token}
     activeDirectoryConfig = {
-          "accessMode": "unrestricted",
-          "certificate": CA_CERTIFICATE,
-          "connectionTimeout": CONNECTION_TIMEOUT,
-          "defaultLoginDomain": DEFAULT_LOGIN_DOMAIN,
-          "groupDNAttribute": "distinguishedName",
-          "groupMemberMappingAttribute": "member",
-          "groupMemberUserAttribute": "distinguishedName",
-          "groupNameAttribute": "name",
-          "groupObjectClass": "group",
-          "groupSearchAttribute": "sAMAccountName",
-          "nestedGroupMembershipEnabled": False,
-          "port": PORT,
-          "servers": [
-              HOSTNAME_OR_IP_ADDRESS
-          ],
-          "serviceAccountUsername": SERVICE_ACCOUNT_NAME,
-          "tls": get_tls(CA_CERTIFICATE),
-          "userDisabledBitMask": 2,
-          "userEnabledAttribute": "userAccountControl",
-          "userLoginAttribute": "sAMAccountName",
-          "userNameAttribute": "name",
-          "userObjectClass": "person",
-          "userSearchAttribute": "sAMAccountName|sn|givenName",
-          "userSearchBase": USER_SEARCH_BASE,
-          "serviceAccountPassword": SERVICE_ACCOUNT_PASSWORD
+        "accessMode": "unrestricted",
+        "certificate": CA_CERTIFICATE,
+        "connectionTimeout": CONNECTION_TIMEOUT,
+        "defaultLoginDomain": DEFAULT_LOGIN_DOMAIN,
+        "groupDNAttribute": "distinguishedName",
+        "groupMemberMappingAttribute": "member",
+        "groupMemberUserAttribute": "distinguishedName",
+        "groupNameAttribute": "name",
+        "groupObjectClass": "group",
+        "groupSearchAttribute": "sAMAccountName",
+        "nestedGroupMembershipEnabled": False,
+        "port": PORT,
+        "servers": [HOSTNAME_OR_IP_ADDRESS],
+        "serviceAccountUsername": SERVICE_ACCOUNT_NAME,
+        "tls": get_tls(CA_CERTIFICATE),
+        "userDisabledBitMask": 2,
+        "userEnabledAttribute": "userAccountControl",
+        "userLoginAttribute": "sAMAccountName",
+        "userNameAttribute": "name",
+        "userObjectClass": "person",
+        "userSearchAttribute": "sAMAccountName|sn|givenName",
+        "userSearchBase": USER_SEARCH_BASE,
+        "serviceAccountPassword": SERVICE_ACCOUNT_PASSWORD
     }
 
     ca_cert = activeDirectoryConfig["certificate"]
     activeDirectoryConfig["certificate"] = ca_cert.replace('\\n', '\n')
 
-    r = requests.post(CATTLE_AUTH_ENABLE_URL, json={
-      "activeDirectoryConfig": activeDirectoryConfig,
-      "enabled": True,
-      "username": username,
-      "password": PASSWORD
-    }, verify=False, headers=headers)
+    r = requests.post(CATTLE_AUTH_ENABLE_URL,
+                      json={"activeDirectoryConfig": activeDirectoryConfig,
+                            "enabled": True,
+                            "username": username,
+                            "password": PASSWORD},
+                      verify=False, headers=headers)
     assert r.status_code == expected_status
-    print("Enable ActiveDirectory request for " + username + " " + str(expected_status))
+    print("Enable ActiveDirectory request for " +
+          username + " " + str(expected_status))
 
 
 def disable_ad(username, token, expected_status=200):
     headers = {'Authorization': 'Bearer ' + token}
-    r = requests.post(CATTLE_AUTH_DISABLE_URL, json={
-      "enabled": False,
-      "username": username,
-      "password": PASSWORD
-    }, verify=False, headers=headers)
+    r = requests.post(CATTLE_AUTH_DISABLE_URL,
+                      json={"enabled": False,
+                            "username": username,
+                            "password": PASSWORD
+                            },
+                      verify=False, headers=headers)
     assert r.status_code == expected_status
-    print("Disable ActiveDirectory request for " + username + " " + str(expected_status))
+    print("Disable ActiveDirectory request for " +
+          username + " " + str(expected_status))
 
 
 def enable_ad_nestedgroups(username, token, expected_status=200):
     headers = {'Authorization': 'Bearer ' + token}
     activeDirectoryConfig = {
-          "accessMode": "unrestricted",
-          "certificate": CA_CERTIFICATE,
-          "connectionTimeout": CONNECTION_TIMEOUT,
-          "defaultLoginDomain": DEFAULT_LOGIN_DOMAIN,
-          "groupDNAttribute": "distinguishedName",
-          "groupMemberMappingAttribute": "member",
-          "groupMemberUserAttribute": "distinguishedName",
-          "groupNameAttribute": "name",
-          "groupObjectClass": "group",
-          "groupSearchAttribute": "sAMAccountName",
-          "nestedGroupMembershipEnabled": True,
-          "port": PORT,
-          "servers": [
-              HOSTNAME_OR_IP_ADDRESS
-          ],
-          "serviceAccountUsername": SERVICE_ACCOUNT_NAME,
-          "tls": get_tls(CA_CERTIFICATE),
-          "userDisabledBitMask": 2,
-          "userEnabledAttribute": "userAccountControl",
-          "userLoginAttribute": "sAMAccountName",
-          "userNameAttribute": "name",
-          "userObjectClass": "person",
-          "userSearchAttribute": "sAMAccountName|sn|givenName",
-          "userSearchBase": USER_SEARCH_BASE,
-          "serviceAccountPassword": SERVICE_ACCOUNT_PASSWORD
+        "accessMode": "unrestricted",
+        "certificate": CA_CERTIFICATE,
+        "connectionTimeout": CONNECTION_TIMEOUT,
+        "defaultLoginDomain": DEFAULT_LOGIN_DOMAIN,
+        "groupDNAttribute": "distinguishedName",
+        "groupMemberMappingAttribute": "member",
+        "groupMemberUserAttribute": "distinguishedName",
+        "groupNameAttribute": "name",
+        "groupObjectClass": "group",
+        "groupSearchAttribute": "sAMAccountName",
+        "nestedGroupMembershipEnabled": True,
+        "port": PORT,
+        "servers": [HOSTNAME_OR_IP_ADDRESS],
+        "serviceAccountUsername": SERVICE_ACCOUNT_NAME,
+        "tls": get_tls(CA_CERTIFICATE),
+        "userDisabledBitMask": 2,
+        "userEnabledAttribute": "userAccountControl",
+        "userLoginAttribute": "sAMAccountName",
+        "userNameAttribute": "name",
+        "userObjectClass": "person",
+        "userSearchAttribute": "sAMAccountName|sn|givenName",
+        "userSearchBase": USER_SEARCH_BASE,
+        "serviceAccountPassword": SERVICE_ACCOUNT_PASSWORD
     }
 
     ca_cert = activeDirectoryConfig["certificate"]
     activeDirectoryConfig["certificate"] = ca_cert.replace('\\n', '\n')
 
-    r = requests.post(CATTLE_AUTH_ENABLE_URL, json={
-      "activeDirectoryConfig": activeDirectoryConfig,
-      "enabled": True,
-      "username": username,
-      "password": PASSWORD
-    }, verify=False, headers=headers)
+    r = requests.post(CATTLE_AUTH_ENABLE_URL,
+                      json={"activeDirectoryConfig": activeDirectoryConfig,
+                            "enabled": True,
+                            "username": username,
+                            "password": PASSWORD},
+                      verify=False, headers=headers)
     assert r.status_code == expected_status
-    print("Enable ActiveDirectory nestedgroup request for " + username + " " + str(expected_status))
+    print("Enable ActiveDirectory nestedgroup request for " +
+          username + " " + str(expected_status))
 
 
 def enable_freeipa(username, token, expected_status=200):
@@ -708,7 +724,8 @@ def enable_freeipa(username, token, expected_status=200):
         "password": PASSWORD
     }, verify=False, headers=headers)
     assert r.status_code == expected_status
-    print("Enable freeIpa request for " + username + " " + str(expected_status))
+    print("Enable freeIpa request for " +
+          username + " " + str(expected_status))
 
 
 def disable_freeipa(username, token, expected_status=200):
@@ -719,7 +736,8 @@ def disable_freeipa(username, token, expected_status=200):
         "password": PASSWORD
     }, verify=False, headers=headers)
     assert r.status_code == expected_status
-    print("Disable freeIpa request for " + username + " " + str(expected_status))
+    print("Disable freeIpa request for " +
+          username + " " + str(expected_status))
 
 
 def principal_lookup(name, token):

--- a/tests/v3_api/test_eks_cluster.py
+++ b/tests/v3_api/test_eks_cluster.py
@@ -1,7 +1,6 @@
 from .common import *  # NOQA
 import pytest
 
-RANCHER_CLEANUP_CLUSTER = os.environ.get('RANCHER_CLEANUP_CLUSTER', "True")
 EKS_ACCESS_KEY = os.environ.get('RANCHER_EKS_ACCESS_KEY', "")
 EKS_SECRET_KEY = os.environ.get('RANCHER_EKS_SECRET_KEY', "")
 EKS_AMI = os.environ.get('RANCHER_EKS_AMI', "")
@@ -24,8 +23,7 @@ def test_create_eks_cluster():
     cluster = validate_cluster(client, cluster, check_intermediate_state=True,
                                skipIngresscheck=True)
 
-    if RANCHER_CLEANUP_CLUSTER == "True":
-        delete_cluster(client, cluster)
+    cluster_cleanup(client, cluster)
 
 
 def get_eks_config():

--- a/tests/v3_api/test_gke_cluster.py
+++ b/tests/v3_api/test_gke_cluster.py
@@ -3,7 +3,6 @@ import requests
 import pytest
 
 CREDENTIALS = os.environ.get('RANCHER_GKE_CREDENTIAL', "")
-RANCHER_CLEANUP_CLUSTER = os.environ.get('RANCHER_CLEANUP_CLUSTER', "True")
 GKE_MASTER_VERSION = os.environ.get('RANCHER_GKE_MASTER_VERSION', "")
 
 gkecredential = pytest.mark.skipif(not CREDENTIALS, reason='GKE Credentials '
@@ -22,8 +21,7 @@ def test_create_gke_cluster():
     cluster = validate_cluster(client, cluster, check_intermediate_state=True,
                                skipIngresscheck=True)
 
-    if RANCHER_CLEANUP_CLUSTER == "True":
-        delete_cluster(client, cluster)
+    cluster_cleanup(client, cluster)
 
 
 def get_gke_version_credentials():


### PR DESCRIPTION
@bmdepesa Can you review the changes?

Following enhancements have been done:
Ability to store cluster name in config files when cluster is not cleaned up.
Ability to not deploy custom cluster when rancher server is deployed.
Fixed flake8 errors for auth tests.