### PR TITLE
Fix RKE tests

### DIFF
--- a/Dockerfile.rke
+++ b/Dockerfile.rke
@@ -1,4 +1,4 @@
-FROM python:2.7.13
+FROM python:3.7.0
 
 ARG RKE_VERSION
 ARG KUBECTL_VERSION=v1.9.0
@@ -14,6 +14,4 @@ RUN wget https://github.com/rancher/rke/releases/download/$RKE_VERSION/rke_linux
     mv kubectl /bin/kubectl && \
     chmod +x /bin/kubectl  && \
     cd $WORKSPACE && \
-    pip install -r requirements.txt && \
-    wget https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml && \
-    mv sonobuoy-conformance.yaml $WORKSPACE/tests/kubernetes_conformance/resources/k8s_ymls/
+    pip install -r requirements.txt

--- a/lib/node.py
+++ b/lib/node.py
@@ -73,7 +73,8 @@ class Node(object):
                 key_filename=self.ssh_key_path, port=self.ssh_port)
             result = self._ssh_client.exec_command(command)
             if result and len(result) == 3 and result[1].readable():
-                result = [result[1].read(), result[2].read()]
+                result = [str(result[1].read(),'utf-8'),
+                          str(result[2].read(),'utf-8')]
         finally:
             self._ssh_client.close()
         return result

--- a/tests/rke/resources/k8s_ymls/daemonset_pods_per_node.yml
+++ b/tests/rke/resources/k8s_ymls/daemonset_pods_per_node.yml
@@ -18,5 +18,5 @@ spec:
         effect: NoSchedule
       containers:
       - name: daemonset-test1
-        image: tjcordingly/container-utils:latest
+        image: sangeetha/mytestcontainer
       terminationGracePeriodSeconds: 30

--- a/tests/rke/resources/k8s_ymls/service_k8test1.yml
+++ b/tests/rke/resources/k8s_ymls/service_k8test1.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
  ports:
  - port: 80
-   targetPort: 5000
+   targetPort: 80
    protocol: TCP
    name: http
  selector:
@@ -29,6 +29,6 @@ spec:
      terminationGracePeriodSeconds: 60
      containers:
      - name: testcontainer
-       image: tjcordingly/container-utils
+       image: sangeetha/mytestcontainer
        ports:
-       - containerPort: 5000
+       - containerPort: 80

--- a/tests/rke/resources/k8s_ymls/service_k8test2.yml
+++ b/tests/rke/resources/k8s_ymls/service_k8test2.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
  ports:
  - port: 80
-   targetPort: 5000
+   targetPort: 80
    protocol: TCP
    name: http
  selector:
@@ -29,6 +29,6 @@ spec:
      terminationGracePeriodSeconds: 60
      containers:
      - name: testcontainer
-       image: tjcordingly/container-utils
+       image: sangeetha/mytestcontainer
        ports:
-       - containerPort: 5000
+       - containerPort: 80

--- a/tests/rke/resources/k8s_ymls/single_pod.yml
+++ b/tests/rke/resources/k8s_ymls/single_pod.yml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: pod-test-util
-        image: tjcordingly/container-utils
+        image: sangeetha/mytestcontainer
         ports:
-        - containerPort: 5000
+        - containerPort: 80

--- a/tests/rke/resources/k8s_ymls/two_container_pod.yaml
+++ b/tests/rke/resources/k8s_ymls/two_container_pod.yaml
@@ -16,9 +16,9 @@ spec:
     spec:
       containers:
       - name: pod-test-util
-        image: tjcordingly/container-utils
+        image: sangeetha/mytestcontainer
         ports:
-        - containerPort: 5000
+        - containerPort: 80
       - name: nginx
         image: nginx
         ports:

--- a/tests/rke/resources/rke_templates/cluster_install_config_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_config_1.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_config_10.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_config_10.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_config_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_config_2.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ dns_hostname_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_config_4.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_config_4.yml.j2
@@ -16,16 +16,3 @@ nodes:
     user: {{ ssh_user_2 }}
     role: [worker]
     hostname_override: {{ hostname_override_2 }}
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_config_5.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_config_5.yml.j2
@@ -16,16 +16,3 @@ nodes:
     user: {{ ssh_user_2 }}
     role: [worker]
     internal_address: {{ internal_address_2 }}
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_config_6.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_config_6.yml.j2
@@ -19,16 +19,3 @@ nodes:
     role: [worker]
     internal_address: {{ internal_address_2 }}
     hostname_override: {{ hostname_override_2 }}
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_config_7.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_config_7.yml.j2
@@ -19,16 +19,3 @@ nodes:
     role: [worker]
     internal_address: {{ internal_address_2 }}
     hostname_override: {{ hostname_override_2 }}
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_config_8.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_config_8.yml.j2
@@ -10,16 +10,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_config_9.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_config_9.yml.j2
@@ -15,16 +15,3 @@ nodes:
     user: {{ ssh_user_2 }}
     role: [worker]
     ssh_key_path: {{ ssh_key_path_2 }}
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_rbac_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_rbac_1.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_roles_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_roles_1.yml.j2
@@ -7,16 +7,3 @@ nodes:
   - address: {{ ip_address_0 }}
     user: {{ ssh_user_0 }}
     role: [controlplane,etcd,worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_roles_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_roles_2.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_roles_3.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_roles_3.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [controlplane,etcd,worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_install_roles_4.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_install_roles_4.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [controlplane,etcd,worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_10_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_10_1.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_10_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_10_2.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [worker,etcd]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_11_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_11_1.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_11_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_11_2.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [worker,etcd]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_12_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_12_1.yml.j2
@@ -19,16 +19,3 @@ nodes:
   - address: {{ ip_address_4 }}
     user: {{ ssh_user_4 }}
     role: [controlplane]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_12_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_12_2.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [controlplane]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_13_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_13_1.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [worker,etcd]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_13_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_13_2.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [worker,etcd]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_14_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_14_1.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [worker,etcd]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_14_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_14_2.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [worker,etcd]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_15_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_15_1.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [worker,etcd]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_15_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_15_2.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [worker,etcd]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_1_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_1_1.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_1_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_1_2.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_2_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_2_1.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_2_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_2_2.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_2_3.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_2_3.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_3_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_3_1.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_3_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_3_2.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [controlplane]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_4_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_4_1.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_4_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_4_2.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [controlplane]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_4_3.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_4_3.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [controlplane]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_5_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_5_1.yml.j2
@@ -7,16 +7,3 @@ nodes:
   - address: {{ ip_address_0 }}
     user: {{ ssh_user_0 }}
     role: [controlplane,etcd,worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_5_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_5_2.yml.j2
@@ -10,16 +10,3 @@ nodes:
   - address: {{ ip_address_1 }}
     user: {{ ssh_user_1 }}
     role: [etcd]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_6_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_6_1.yml.j2
@@ -7,16 +7,3 @@ nodes:
   - address: {{ ip_address_0 }}
     user: {{ ssh_user_0 }}
     role: [controlplane,etcd,worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_6_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_6_2.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [etcd]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_7_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_7_1.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [etcd]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_8_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_8_1.yml.j2
@@ -7,16 +7,3 @@ nodes:
   - address: {{ ip_address_0 }}
     user: {{ ssh_user_0 }}
     role: [controlplane,etcd,worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_8_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_8_2.yml.j2
@@ -10,16 +10,3 @@ nodes:
   - address: {{ ip_address_1 }}
     user: {{ ssh_user_1 }}
     role: [controlplane,etcd,worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_9_1.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_9_1.yml.j2
@@ -13,16 +13,3 @@ nodes:
   - address: {{ ip_address_2 }}
     user: {{ ssh_user_2 }}
     role: [worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/resources/rke_templates/cluster_update_roles_9_2.yml.j2
+++ b/tests/rke/resources/rke_templates/cluster_update_roles_9_2.yml.j2
@@ -16,16 +16,3 @@ nodes:
   - address: {{ ip_address_3 }}
     user: {{ ssh_user_3 }}
     role: [controlplane,worker]
-services:
-  etcd:
-    image: quay.io/coreos/etcd:latest
-  kube-api:
-    image: {{ k8_rancher_image }}
-  kube-controller:
-    image: {{ k8_rancher_image }}
-  scheduler:
-    image: {{ k8_rancher_image }}
-  kubelet:
-    image: {{ k8_rancher_image }}
-  kubeproxy:
-    image: {{ k8_rancher_image }}

--- a/tests/rke/test_install_config.py
+++ b/tests/rke/test_install_config.py
@@ -62,7 +62,7 @@ def test_install_config_5(test_name, cloud_provider, rke_client, kubectl):
     nodes = cloud_provider.create_multiple_nodes(3, test_name)
     create_and_validate(
         cloud_provider, rke_client, kubectl, rke_template, nodes,
-        remove_nodes=True)
+        remove_nodes=True, etcd_private_ip=True)
 
 
 def test_install_config_6(test_name, cloud_provider, rke_client, kubectl):
@@ -76,7 +76,7 @@ def test_install_config_6(test_name, cloud_provider, rke_client, kubectl):
         node.node_name = node.host_name
     create_and_validate(
         cloud_provider, rke_client, kubectl, rke_template, nodes,
-        remove_nodes=True)
+        remove_nodes=True, etcd_private_ip=True)
 
 
 def test_install_config_7(test_name, cloud_provider, rke_client, kubectl):
@@ -92,7 +92,7 @@ def test_install_config_7(test_name, cloud_provider, rke_client, kubectl):
         index += 1
     create_and_validate(
         cloud_provider, rke_client, kubectl, rke_template, nodes,
-        remove_nodes=True)
+        remove_nodes=True, etcd_private_ip=True)
 
 
 def test_install_config_8(test_name, cloud_provider, rke_client, kubectl):


### PR DESCRIPTION
@galal-hussein Can you review the changes?
Fixes made in the following area:
1. Move to python 3.7
2. Move to subprocess instead of invoke
3.  Pin version ETCDCTL_API=2 for etcdctl commands
4. Use nodes private ip address (instead of localhost) in case where internal_address is used
5. Exclude control plane nodes from schedulable list of nodes
6. Change  image used for container deployments.
7. Disabled conformance tests 