### PR TITLE
Removed gke,eks,aks related testcases from being executed as part of onTag provisioning case.

### DIFF
--- a/lib/aws.py
+++ b/lib/aws.py
@@ -315,3 +315,15 @@ class AmazonWebServices(CloudProviderBase):
         if wait_for_deleted:
             for node in nodes:
                 node = self.wait_for_node_state(node, 'terminated')
+
+    def delete_keypairs(self, name_prefix):
+        if len(name_prefix) > 0:
+            key_pairs = self._client.describe_key_pairs()
+            print(key_pairs["KeyPairs"])
+            key_pair_list = key_pairs["KeyPairs"]
+            print(len(key_pair_list))
+            for key in key_pair_list:
+                keyName = key["KeyName"]
+                if keyName.startswith(name_prefix):
+                    print(keyName)
+                    self._client.delete_key_pair(KeyName=keyName)

--- a/tests/v3_api/Jenkinsfile_provisioning_tests
+++ b/tests/v3_api/Jenkinsfile_provisioning_tests
@@ -28,7 +28,6 @@ node {
                 jobs["do"] = { build job: 'v3_test_do_cluster', parameters: params }
                 jobs["ec2"] = { build job: 'v3_test_ec2_cluster', parameters: params }
                 jobs["az"] = { build job: 'v3_test_az_cluster', parameters: params }
-                jobs["eks_gke_aks"] = { build job: 'v3_test_gke_eks_aks_clusters', parameters: params }
 
                 parallel jobs
             }

--- a/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
+++ b/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
@@ -70,7 +70,6 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                     jobs["do"] = { build job: 'v3_test_do_cluster', parameters: params }
                     jobs["ec2"] = { build job: 'v3_test_ec2_cluster', parameters: params }
                     jobs["az"] = { build job: 'v3_test_az_cluster', parameters: params }
-                    jobs["eks_gke_aks"] = { build job: 'v3_test_gke_eks_aks_clusters', parameters: params }
 
                     parallel jobs
                 }

--- a/tests/v3_api/test_custom_host_reg.py
+++ b/tests/v3_api/test_custom_host_reg.py
@@ -13,6 +13,7 @@ rke_config = {"authentication": {"type": "authnConfig", "strategy": "x509"},
               }
 AUTO_DEPLOY_CUSTOM_CLUSTER = ast.literal_eval(
     os.environ.get('RANCHER_AUTO_DEPLOY_CUSTOM_CLUSTER', "True"))
+KEYPAIR_NAME_PREFIX = os.environ.get('RANCHER_KEYPAIR_NAME_PREFIX', "")
 
 
 def test_add_custom_host():
@@ -21,6 +22,10 @@ def test_add_custom_host():
     if AGENT_REG_CMD != "":
         for aws_node in aws_nodes:
             aws_node.execute_command(AGENT_REG_CMD)
+
+
+def test_delete_keypair():
+    AmazonWebServices().delete_keypairs(KEYPAIR_NAME_PREFIX)
 
 
 def test_deploy_rancher_server():
@@ -78,7 +83,7 @@ def test_delete_rancher_server():
             exceptionMsg = 'Timeout waiting for clusters to be removed'
             raise Exception(exceptionMsg)
     ip_address = CATTLE_TEST_URL[8:]
-    print ("Ip Address:" + ip_address)
+    print("Ip Address:" + ip_address)
     filters = [
         {'Name': 'network-interface.addresses.association.public-ip',
          'Values': [ip_address]}]

--- a/tests/v3_api/test_service_discovery.py
+++ b/tests/v3_api/test_service_discovery.py
@@ -76,7 +76,6 @@ def validate_dns_record_for_workload(workload, scale, record,
 
 
 def test_service_discovery_when_workload_scale_up():
-    p_client = namespace["p_client"]
     con = [{"name": "test1",
             "image": TEST_CLIENT_IMAGE}]
     name = random_test_name("test-sd-up")
@@ -97,8 +96,6 @@ def test_service_discovery_when_workload_scale_up():
 
 
 def test_service_discovery_when_workload_scale_down():
-    p_client = namespace["p_client"]
-    ns = namespace["ns"]
     con = [{"name": "test1",
             "image": TEST_CLIENT_IMAGE}]
     name = random_test_name("test-sd-dw")

--- a/tests/v3_api/test_workload.py
+++ b/tests/v3_api/test_workload.py
@@ -309,9 +309,9 @@ def test_wl_with_clusterIp():
             "image": TEST_CLIENT_IMAGE}]
 
     workload_for_test = p_client.create_workload(name=wlname,
-                                        containers=con,
-                                        namespaceId=ns.id,
-                                        scale=2)
+                                                 containers=con,
+                                                 namespaceId=ns.id,
+                                                 scale=2)
     wait_for_wl_to_active(p_client, workload_for_test)
     test_pods = wait_for_pods_in_workload(p_client, workload_for_test, 2)
     validate_clusterIp(p_client, workload, cluster_ip, test_pods)
@@ -361,12 +361,11 @@ def test_wl_with_clusterIp_sacle_and_upgrade():
     cluster_ip = sd_records[0].clusterIp
     # get test pods
     wlname = random_test_name("testclusterip-client")
-    wl_con = [{"name": "test1",
-            "image": TEST_CLIENT_IMAGE}]
+    wl_con = [{"name": "test1", "image": TEST_CLIENT_IMAGE}]
     workload_for_test = p_client.create_workload(name=wlname,
-                                        containers=wl_con,
-                                        namespaceId=ns.id,
-                                        scale=2)
+                                                 containers=wl_con,
+                                                 namespaceId=ns.id,
+                                                 scale=2)
     wait_for_wl_to_active(p_client, workload_for_test)
     test_pods = wait_for_pods_in_workload(p_client, workload_for_test, 2)
     validate_clusterIp(p_client, workload, cluster_ip, test_pods)


### PR DESCRIPTION
@bmdepesa Can you review the following changes done in this pr?

Removed gke,eks,aks related testcases from being executed as part of onTag provisioning
Provided method to delete keypairs from aws
Flake8 fixes