### PR TITLE
fix the bug where the post-upgrade test fails when testing on rancher v2.0.x

### DIFF
--- a/tests/v3_api/test_upgrade.py
+++ b/tests/v3_api/test_upgrade.py
@@ -182,7 +182,7 @@ def modify_workload_validate_deployment():
 
     workload = p_client.list_workload(
         name=wl_name_validate, namespace=validate_prefix + ns.id).data[0]
-    p_client.update(workload, scale=4)
+    p_client.update(workload, scale=4, containers=workload.containers)
     validate_wl(wl_name_validate, 4)
 
 
@@ -198,7 +198,7 @@ def modify_workload_validate_ingress():
         name=ingress_wlname2_validate, namespace=ns.id).data[0]
     print(ing_workload)
     # Increment workload
-    ing_workload = p_client.update(ing_workload, scale=4)
+    ing_workload = p_client.update(ing_workload, scale=4, containers=ing_workload.containers)
     wait_for_pods_in_workload(p_client, ing_workload, 4)
     validate_wl(ing_workload.name, 4)
 
@@ -215,7 +215,7 @@ def modify_workload_validate_sd():
     # Get sd workloads and validate service discovery
     sd_workload = p_client.list_workload(
         name=sd_wlname2_validate, namespace=ns.id).data[0]
-    p_client.update(sd_workload, scale=3)
+    p_client.update(sd_workload, scale=3, containers=sd_workload.containers)
     validate_wl(sd_wlname2_validate, 3)
 
     validate_service_discovery(sd_name_validate,
@@ -232,7 +232,7 @@ def modify_workload_validate_secret():
     secret_workload1 = p_client.list_workload(
         name=secret_wl_name1_validate, namespace=ns.id).data[0]
 
-    secret_workload1 = p_client.update(secret_workload1, scale=3)
+    secret_workload1 = p_client.update(secret_workload1, scale=3, containers=secret_workload1.containers)
     wait_for_pods_in_workload(p_client, secret_workload1, 3)
     validate_workload_with_secret(
         p_client, secret_workload1, "deployment", ns.name,
@@ -241,7 +241,7 @@ def modify_workload_validate_secret():
     secret_workload2 = p_client.list_workload(name=secret_wl_name2_validate,
                                               namespace=ns.id).data[0]
 
-    secret_workload2 = p_client.update(secret_workload2, scale=3)
+    secret_workload2 = p_client.update(secret_workload2, scale=3, containers=secret_workload2.containers)
     wait_for_pods_in_workload(p_client, secret_workload2, 3)
     validate_workload_with_secret(
         p_client, secret_workload2, "deployment", ns.name,


### PR DESCRIPTION
The function `upgrade` asks for the value of `containers` when being used. So what I did is adding the third parameter `containers` to all `upgrade` function calls in `test_upgrade.py` to fix the bug.

The automatiaion pipeline in Jenkins using the new code also succeeded.