### PR TITLE
Test for netes-default SA

### DIFF
--- a/tests/v3_api/test_sa.py
+++ b/tests/v3_api/test_sa.py
@@ -1,0 +1,26 @@
+import pytest
+
+from .common import *  # NOQA
+
+do_test_sa = \
+    ast.literal_eval(os.environ.get('RANCHER_SA_CHECK', "True"))
+
+if_test_sa = pytest.mark.skipif(
+    do_test_sa is not True,
+    reason="This test should not be executed on imported clusters")
+
+
+@if_test_sa
+def test_sa_for_user_clusters():
+    cmd = "get serviceaccounts -n default"
+    out = execute_kubectl_cmd(cmd, False, False)
+    assert "netes-default" not in out
+    cmd = "get serviceaccounts -n cattle-system"
+    out = execute_kubectl_cmd(cmd, False, False)
+    assert "kontainer-engine" in out
+
+
+@pytest.fixture(scope='module', autouse="True")
+def create_cluster_client(request):
+    client, cluster = get_admin_client_and_cluster()
+    create_kubeconfig(cluster)


### PR DESCRIPTION
This test checks that `netes-default` SA does not exist in `default` namespace, and that `kontainer-engine` SA is present in `cattle-system`

@sangeethah 