### PR TITLE
Update RKE cluster configuration and use cloud creds

### DIFF
--- a/lib/cloud_provider.py
+++ b/lib/cloud_provider.py
@@ -5,7 +5,7 @@ from invoke import run
 
 class CloudProviderBase(object, metaclass=abc.ABCMeta):
     OS_VERSION = os.environ.get("OS_VERSION", 'ubuntu-16.04')
-    DOCKER_VERSION = os.environ.get("DOCKER_VERSION", '17.03')
+    DOCKER_VERSION = os.environ.get("DOCKER_VERSION", '18.09')
     DOCKER_INSTALLED = os.environ.get("DOCKER_INSTALLED", "true")
 
     @abc.abstractmethod


### PR DESCRIPTION
@bmdepesa @sowmyav27 Could you please review the following changes ?

1. Using cloud creds for Node templates
2. Changed RKE cluster configurations to match with what UI sets in 2.2 version
3. Disabled ingress check as part of cluster validation .From the testing done so far , it sometime takes very long time for ingress to get to "active" state and even after introducing the code to wait for ingress to "active" state , test reports "503 errors". So disabling ingress check for now , so that we allow for other cluster update scenarios to be tested.
4. Changed the cluster state check to "provisioning" from "active" for custom clusters to reflect the behavior in 2.2.
5. Updated docker version for Node templates to 18.09
6. Updated docker version on AWS nodes (added to custom cluster) to 18.09