### PR TITLE
Support multiple branches in pipelines

### DIFF
--- a/tests/v3_api/Jenkinsfile
+++ b/tests/v3_api/Jenkinsfile
@@ -3,7 +3,6 @@
 // Optional: AWS_SSH_PEM_KEY, AWS_SSH_KEY_NAME, DEBUG
 
 node {
-
   def rootPath = "/src/rancher-validation/"
   def testContainer = "${JOB_NAME}${env.BUILD_NUMBER}_test"
 
@@ -12,10 +11,20 @@ node {
   def imageName = "rancher-validation-tests"
   def testsDir = "tests/v3_api/"
 
+  def branch = "master"
+  if ("${env.branch}" != "null" && "${env.branch}" != "") {
+    branch = "${env.branch}"
+  }
+
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
     stage('Checkout') {
       deleteDir()
-      checkout scm
+      checkout([
+                $class: 'GitSCM',
+                branches: [[name: "*/${branch}"]],
+                extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                userRemoteConfigs: scm.userRemoteConfigs
+              ])
     }
 
     stage('Configure and Build') {
@@ -36,7 +45,6 @@ node {
         } catch(err) {
           echo 'Test run had failures. Collecting results...'
         }
-
       }
 
       stage('Test Report') {

--- a/tests/v3_api/Jenkinsfile_deploy_and_test
+++ b/tests/v3_api/Jenkinsfile_deploy_and_test
@@ -15,10 +15,20 @@ node {
   def envFile = ".env"
   def rancherConfig = "rancher_env.config"
 
+  def branch = "master"
+  if ("${env.branch}" != "null" && "${env.branch}" != "") {
+    branch = "${env.branch}"
+  }
+
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
     stage('Checkout') {
       deleteDir()
-      checkout scm
+      checkout([
+                $class: 'GitSCM',
+                branches: [[name: "*/${branch}"]],
+                extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                userRemoteConfigs: scm.userRemoteConfigs
+              ])
     }
 
     stage('Configure and Build') {

--- a/tests/v3_api/Jenkinsfile_deploy_and_test_ontag
+++ b/tests/v3_api/Jenkinsfile_deploy_and_test_ontag
@@ -37,6 +37,10 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
   println("** This will **not** result in a pipeline run.")
   currentBuild.result = lastBuildResult()
 } else {
+  def branch = "v2.1"
+  if (rancher_version.startsWith("v2.2")) {
+    branch = "master"
+  }
   try {
     node {
       def rootPath = "/src/rancher-validation/"
@@ -56,7 +60,12 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
       wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
         stage('Checkout') {
             deleteDir()
-            checkout scm
+            checkout([
+                      $class: 'GitSCM',
+                      branches: [[name: "*/${branch}"]],
+                      extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                      userRemoteConfigs: scm.userRemoteConfigs
+                    ])
         }
 
         stage('Configure and Build') {

--- a/tests/v3_api/Jenkinsfile_provisioning_tests
+++ b/tests/v3_api/Jenkinsfile_provisioning_tests
@@ -7,11 +7,21 @@ def imageName = "rancher-validation-tests"
 def envFile = ".env"
 def RANCHER_DEPLOYED = false
 
+def branch = "master"
+if ("${env.branch}" != "null" && "${env.branch}" != "") {
+  branch = "${env.branch}"
+}
+
 node {
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
     stage('Checkout') {
       deleteDir()
-      checkout scm
+      checkout([
+                $class: 'GitSCM',
+                branches: [[name: "*/${branch}"]],
+                extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                userRemoteConfigs: scm.userRemoteConfigs
+              ])
     }
 
     try {
@@ -42,7 +52,7 @@ node {
       }
 
       stage('Run provisioning tests') {
-        params = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"), string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}") ]
+        params = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"), string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"), string(name: 'branch', value: "${branch}") ]
 
         jobs["custom"] = { build job: 'v3_test_custom_cluster', parameters: params}
         jobs["do"] = { build job: 'v3_test_do_cluster', parameters: params }

--- a/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
+++ b/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
@@ -46,11 +46,20 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
   println("** This will **not** result in a pipeline run.")
   currentBuild.result = lastBuildResult()
 } else {
+  def branch = "v2.1"
+  if (rancher_version.startsWith("v2.2")) {
+    branch = "master"
+  }
   node {
     wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
       stage('Checkout') {
         deleteDir()
-        checkout scm
+        checkout([
+                  $class: 'GitSCM',
+                  branches: [[name: "*/${branch}"]],
+                  extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                  userRemoteConfigs: scm.userRemoteConfigs
+                ])
       }
 
       try {
@@ -81,7 +90,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
         }
 
         stage('Run provisioning tests') {
-          params = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"), string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}") ]
+          params = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"), string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"), string(name: 'branch', value: "${branch}") ]
 
           jobs["custom"] = { build job: 'v3_test_custom_cluster', parameters: params}
           jobs["do"] = { build job: 'v3_test_do_cluster', parameters: params }

--- a/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -38,6 +38,10 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
   println("** This will **not** result in a pipeline run.")
   currentBuild.result = lastBuildResult()
 } else {
+  def branch = "v2.1"
+  if (rancher_version.startsWith("v2.2")) {
+    branch = "master"
+  }
   try {
     node {
       def rootPath = "/src/rancher-validation/"
@@ -67,7 +71,12 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
       wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
         stage('Checkout') {
             deleteDir()
-            checkout scm
+            checkout([
+                      $class: 'GitSCM',
+                      branches: [[name: "*/${branch}"]],
+                      extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                      userRemoteConfigs: scm.userRemoteConfigs
+                    ])
         }
 
         stage('Configure and Build') {
@@ -123,11 +132,13 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
 
                 params = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"),
                            string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"),
-                           string(name: 'RANCHER_SERVER_VERSION', value: "${rancher_version}") ]
+                           string(name: 'RANCHER_SERVER_VERSION', value: "${rancher_version}"), 
+                           string(name: 'branch', value: "${branch}") ]
 
                 params2 = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL_2}"),
-                           string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN_2}"),
-                           string(name: 'RANCHER_SERVER_VERSION', value: "${rancher_version}") ]
+                            string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN_2}"),
+                            string(name: 'RANCHER_SERVER_VERSION', value: "${rancher_version}"),
+                            string(name: 'branch', value: "${branch}") ]
 
                 jobs["do"] = { build job: 'v3_ontag_do_provision_api', parameters: params }
                 jobs["ec2"] = { build job: 'v3_ontag_ec2_provision_api', parameters: params }

--- a/tests/v3_api/scripts/pipeline/Jenkinsfile_provision_and_test
+++ b/tests/v3_api/scripts/pipeline/Jenkinsfile_provision_and_test
@@ -22,10 +22,20 @@ node {
 
   def PYTEST_OPTIONS = "-k \"" + TESTS_TO_RUN.join(" or ") +"\""
 
+  def branch = "master"
+  if ("${env.branch}" != "null" && "${env.branch}" != "") {
+    branch = "${env.branch}"
+  }
+
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
     stage('Checkout') {
       deleteDir()
-      checkout scm
+      checkout([
+                $class: 'GitSCM',
+                branches: [[name: "*/${branch}"]],
+                extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                userRemoteConfigs: scm.userRemoteConfigs
+              ])
     }
 
     stage('Configure and Build') {


### PR DESCRIPTION
To support different branches in our pipelines we need to address 3 areas:

* Default branch if param is not explicitly set on the job -- this is set to `master`
* For ontag jobs, set the default branch to `v2.1` unless the tag from Dockerhub begins with `v2.2`, then set the branch to `master`
* Checkout the branch (change from checkout scm to explicit values)