### PR TITLE
fix the branch version

### DIFF
--- a/tests/v3_api/Jenkinsfile_deploy_and_test_ontag
+++ b/tests/v3_api/Jenkinsfile_deploy_and_test_ontag
@@ -38,7 +38,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
   currentBuild.result = lastBuildResult()
 } else {
   def branch = "v2.1"
-  if (rancher_version.startsWith("v2.2")) {
+  if (rancher_version.startsWith("v2.2") || rancher_version == "master" ) {
     branch = "master"
   }
   try {

--- a/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
+++ b/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
@@ -47,7 +47,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
   currentBuild.result = lastBuildResult()
 } else {
   def branch = "v2.1"
-  if (rancher_version.startsWith("v2.2")) {
+  if (rancher_version.startsWith("v2.2") || rancher_version == "master" ) {
     branch = "master"
   }
   node {

--- a/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -39,7 +39,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
   println("** This will **not** result in a pipeline run.")
   currentBuild.result = lastBuildResult()
 } else {
-  if (rancher_version.startsWith("v2.2")) {
+  if (rancher_version.startsWith("v2.2") || rancher_version == "master") {
     branch = "master"
   }
   try {
@@ -141,10 +141,13 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                             string(name: 'RANCHER_SERVER_VERSION', value: "${rancher_version}"),
                             string(name: 'BRANCH', value: branch) ]
 
+                // Rancher server 1 is used to test RKE clusters
                 jobs["do"] = { build job: 'v3_ontag_do_provision_api', parameters: params }
                 jobs["ec2"] = { build job: 'v3_ontag_ec2_provision_api', parameters: params }
                 jobs["az"] = { build job: 'v3_ontag_az_provision_api', parameters: params }
                 jobs["custom"] = { build job: 'v3_ontag_custom_provision_api', parameters: params}
+
+                // Rancher server 2 is used to test GKE, EKS, AKS and Imported clusters
                 jobs["gke"] = { build job: 'v3_ontag_gke_provision_api', parameters: params2 }
                 jobs["eks"] = { build job: 'v3_ontag_eks_provision_api', parameters: params2 }
                 jobs["aks"] = { build job: 'v3_ontag_aks_provision_api', parameters: params2 }


### PR DESCRIPTION
Problem:

The branch is not set to `master` when running automation on rancher: master, which causes the failure of provisioning RKE clusters. 
 
Solution:

Set `branch` to `master` if `rancher_version` is `master`