### PR TITLE
fix the bug where a list is passed as a list of lists

### DIFF
--- a/tests/v3_api/common.py
+++ b/tests/v3_api/common.py
@@ -553,7 +553,7 @@ def validate_cluster(client, cluster, intermediate_state="provisioning",
         client, cluster,
         check_intermediate_state=check_intermediate_state,
         intermediate_state=intermediate_state,
-        nodes_not_in_active_state=[nodes_not_in_active_state])
+        nodes_not_in_active_state=nodes_not_in_active_state)
     # Create Daemon set workload and have an Ingress with Workload
     # rule pointing to this daemonset
     create_kubeconfig(cluster)


### PR DESCRIPTION
Problem:
The expected data is a list, but we pass the data as a list of lists, such that it will wait for an unavailable node (the node is deleted from AWS console directly but not from Rancher UI) to be available which is impossible, therefore the pipeline fails.

Solution:
pass in the data as a list. 