### PR TITLE
Single click upgrade for single-node Rancher install

### DIFF
--- a/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade
+++ b/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade
@@ -1,0 +1,270 @@
+#!groovy
+
+node {
+  def rootPath = "/src/rancher-validation/"
+  def containerPrefix = "${JOB_NAME}${BUILD_NUMBER}"
+
+  def rancherConfig = "rancher_env.config"
+  def imageName = "rancher-validation-tests"
+  def testsDir = "tests/v3_api/"
+
+  def pre_branch = PREUPGRADE_BRANCH
+  def post_branch = POSTUPGRADE_BRANCH
+
+  def buildFail = false
+
+  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+    stage('Prechecks & checkout preupgrade branch') {
+      if (RANCHER_SERVER_VERSION == "") {
+        currentBuild.result = 'ABORTED'
+        error("RANCHER_SERVER_VERSION must be provided!")
+      }
+
+      if (RANCHER_SERVER_VERSION_UPGRADE == "") {
+        currentBuild.result = 'ABORTED'
+        error("RANCHER_SERVER_VERSION_UPGRADE must be provided!")
+      }
+
+      if (PREUPGRADE_BRANCH == "") {
+        currentBuild.result = 'ABORTED'
+        error("PREUPGRADE_BRANCH must be provided!")
+      }
+
+      if (POSTUPGRADE_BRANCH == "") {
+        currentBuild.result = 'ABORTED'
+        error("POSTUPGRADE_BRANCH must be provided!")
+      }
+
+      deleteDir()
+      checkout([
+                $class: 'GitSCM',
+                branches: [[name: "*/${pre_branch}"]],
+                extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                userRemoteConfigs: scm.userRemoteConfigs
+              ])
+      
+      if (RANCHER_EXTRA_VARS != "" && RANCHER_EXTRA_VARS != null) {
+        echo "${RANCHER_EXTRA_VARS}"
+        writeFile(file: "preenv.config", text: "${RANCHER_EXTRA_VARS}")
+        load "preenv.config"
+      } 
+    }
+
+    stage('Configure and Build') {
+      sh "./tests/v3_api/scripts/configure.sh"
+      if (AWS_SSH_PEM_KEY && AWS_SSH_KEY_NAME) {
+        dir(".ssh") {
+          writeFile(file: "${AWS_SSH_KEY_NAME}", text: "${AWS_SSH_PEM_KEY}")
+        } 
+        sh "chmod 400 .ssh/*"
+      }
+      sh "./tests/v3_api/scripts/build.sh"
+    }
+
+    stage('Deploy Rancher server') {
+      try {
+        sh "docker run --name ${containerPrefix}_deploy -t --env-file .env " +
+            "${imageName} /bin/bash -c \'" +
+            "pytest -v -s --junit-xml=deploy.xml " +
+            "-k test_deploy_rancher_server ${testsDir}\'"
+
+            sh "docker cp ${containerPrefix}_deploy:${rootPath}${testsDir}${rancherConfig} ."
+            load rancherConfig
+      } catch(err) {
+        buildFail = true
+        echo "Error: " + err
+        echo "Deploy Rancher server failed"
+        currentBuild.result = 'FAILURE'
+      }
+    }
+
+    stage('Provision cluster') {
+      try {
+        sh "docker run --name ${containerPrefix}_provision  --env-file .env " +
+          "${imageName} /bin/bash -c \'" +
+          "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " +
+          "export ADMIN_TOKEN=${ADMIN_TOKEN} && " + 
+          "pytest -v -s --junit-xml=provision.xml -k test_rke_${RANCHER_CLUSTER_TYPE}_host_${RANCHER_CLUSTER_PROFILE} ${testsDir}\'"
+      } catch(err) {
+        buildFail = true
+        echo "Error: " + err
+        echo "Provision cluster failed."
+        currentBuild.result = 'FAILURE'
+      }
+    }
+
+    stage('Run preupgrade') {
+      try {
+        sh "docker run --name ${containerPrefix}_preupgrade  --env-file .env " +
+           "${imageName} /bin/bash -c \'" +
+           "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
+           "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+           "export RANCHER_VALIDATE_RESOURCES_PREFIX=autopre && " +
+           "export RANCHER_CREATE_RESOURCES_PREFIX=autopre && " +
+           "export RANCHER_UPGRADE_CHECK=preupgrade && " +
+           "export RANCHER_INGRESS_CHECK=True && " +
+           "export RANCHER_ENABLE_HOST_NODE_PORT_TESTS=True && " +
+           "export RANCHER_SKIP_INGRESS=False && " +
+           "export RANCHER_CHECK_FOR_LB=False && " +
+           "pytest -v -s --junit-xml=preupgrade.xml -k test_upgrade ${testsDir}\'"
+      } catch(err) {
+        buildFail = true
+        echo "Error: " + err
+        echo "Preupgrade tests failed"
+        currentBuild.result = 'UNSTABLE'
+      }
+    }
+
+    stage('Checkout postupgrade branch & rebuild') {
+      checkout([
+                $class: 'GitSCM',
+                branches: [[name: "*/${post_branch}"]],
+                extensions: scm.extensions,
+                userRemoteConfigs: scm.userRemoteConfigs
+              ])
+
+      sh "./tests/v3_api/scripts/build.sh"
+      sh "./tests/v3_api/scripts/configure.sh"
+    }
+
+    stage('Run upgrade') {
+      try {
+        sh "docker run --name ${containerPrefix}_upgrade  --env-file .env " +
+           "${imageName} /bin/bash -c \'" +
+           "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
+           "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+           "export RANCHER_UPGRADE_CHECK=upgrade_rancher && " +
+           "pytest -v -s --junit-xml=upgrade.xml -k test_rancher_upgrade ${testsDir}\'"
+      } catch(err) {
+        buildFail = true
+        echo "Error: " + err
+        echo "Upgrade Rancher failed."
+        currentBuild.result = 'FAILURE'
+      }
+    }
+
+    stage('Run postupgrade tests') {
+      try {
+        sleep(time: 5, unit: "MINUTES")
+         sh "docker run --name ${containerPrefix}_postupgrade  --env-file .env " + \
+           "${imageName} /bin/bash -c \'" + 
+           "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
+           "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+           "export RANCHER_VALIDATE_RESOURCES_PREFIX=autopre && " +
+           "export RANCHER_CREATE_RESOURCES_PREFIX=autopost && " +
+           "export RANCHER_UPGRADE_CHECK=postupgrade && " +
+           "export RANCHER_INGRESS_CHECK=True && " +
+           "export RANCHER_ENABLE_HOST_NODE_PORT_TESTS=True && " +
+           "export RANCHER_SKIP_INGRESS=False && " +
+           "export RANCHER_CHECK_FOR_LB=False && " +
+           "pytest -v -s --junit-xml=postupgrade.xml -k test_upgrade ${testsDir}\'"
+      } catch(err) {
+        buildFail = true
+        currentBuild.result = 'UNSTABLE'
+        echo "Error: " + err
+        echo "Postupgrade tests failed"
+      }
+    }  
+
+    stage('Upgrade k8s') {
+      try {
+        if (RANCHER_K8S_VERSION_UPGRADE != null && RANCHER_K8S_VERSION_UPGRADE != "") {
+          sh "docker run --name ${containerPrefix}_k8supgrade  --env-file .env " +
+            "${imageName} /bin/bash -c \'" +
+            "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
+            "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+            "pytest -v -s --junit-xml=k8supgrade.xml -k test_edit_cluster_k8s_version ${testsDir}\'"
+        }
+      } catch(err) {
+        buildFail = true
+        echo "Error: " + err
+        echo "Upgrade cluster k8s failed."
+        currentBuild.result = 'FAILURE'
+      }
+    }
+
+    stage('Run postupgrade scripts') {
+      try {
+        if (RANCHER_K8S_VERSION_UPGRADE != null && RANCHER_K8S_VERSION_UPGRADE != "") {
+          sh "docker run --name ${containerPrefix}_k8spostupgrade  --env-file .env " +
+            "${imageName} /bin/bash -c \'" + 
+            "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
+            "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+            "export RANCHER_VALIDATE_RESOURCES_PREFIX=autopost && " +
+            "export RANCHER_CREATE_RESOURCES_PREFIX=autopost2 && " +
+            "export RANCHER_UPGRADE_CHECK=postupgrade && " +
+            "export RANCHER_INGRESS_CHECK=True && " +
+            "export RANCHER_ENABLE_HOST_NODE_PORT_TESTS=True && " +
+            "export RANCHER_SKIP_INGRESS=False && " +
+            "export RANCHER_CHECK_FOR_LB=False && " +
+            "pytest -v -s --junit-xml=k8spostupgrade.xml -k test_upgrade ${testsDir}\'"
+        }
+      } catch(err) {
+        buildFail = true
+        echo "Error: " + err
+        echo "k8s postupgrade scripts failed"
+        currentBuild.result = 'UNSTABLE'
+      }
+    }
+
+    stage('Delete Rancher Server') {
+      try {
+        if (RANCHER_DELETE_SERVER.toLowerCase() == "true" && buildFail == false) {
+          sh "docker run --name ${containerPrefix}_delete -t --env-file .env " + 
+           "${imageName} /bin/bash -c \'" +
+           "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
+           "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+           "pytest -v -s --junit-xml=delete.xml " +
+           "-k test_delete_rancher_server ${testsDir}\'"
+        } else {
+          echo "Build failed or RANCHER_DELETE_SERVER is set to false"
+          echo "SERVER IS NOT DELETED"
+        }
+      } catch(err) {
+        echo "Error: " + err
+        error()
+        currentBuild.result = 'FAILURE'
+      }
+    }
+
+    stage('Test Reports') {
+      try {
+        sh "docker cp ${containerPrefix}_deploy:${rootPath}deploy.xml ."
+        sh "docker cp ${containerPrefix}_provision:${rootPath}provision.xml ."
+        sh "docker cp ${containerPrefix}_preupgrade:${rootPath}preupgrade.xml ."
+        sh "docker cp ${containerPrefix}_upgrade:${rootPath}upgrade.xml ."
+        sh "docker cp ${containerPrefix}_postupgrade:${rootPath}postupgrade.xml ."
+        
+        if (RANCHER_K8S_VERSION_UPGRADE != null && RANCHER_K8S_VERSION_UPGRADE != "") {
+          sh "docker cp ${containerPrefix}_k8supgrade:${rootPath}k8supgrade.xml ."
+          sh "docker cp ${containerPrefix}_k8spostupgrade:${rootPath}k8spostupgrade.xml ."  
+        }
+        
+        if (RANCHER_DELETE_SERVER.toLowerCase() == "true" && buildFail == false) {
+          sh "docker cp ${containerPrefix}_delete:${rootPath}delete.xml ."
+        }
+        
+        step([$class: 'JUnitResultArchiver', testResults: "**/*.xml"])
+      } catch(err) {
+        echo "Error: " + err
+      }
+    }
+
+    stage('Cleanup') {
+      sh "docker rm ${containerPrefix}_deploy"
+      sh "docker rm ${containerPrefix}_provision"
+      sh "docker rm ${containerPrefix}_preupgrade"
+      sh "docker rm ${containerPrefix}_upgrade"
+      sh "docker rm ${containerPrefix}_postupgrade"
+
+      if (RANCHER_K8S_VERSION_UPGRADE != null && RANCHER_K8S_VERSION_UPGRADE != "") {
+        sh "docker rm ${containerPrefix}_k8supgrade"
+        sh "docker rm ${containerPrefix}_k8spostupgrade"
+      }
+
+      if (RANCHER_DELETE_SERVER.toLowerCase() == "true" && buildFail == false) {
+        sh "docker rm  ${containerPrefix}_delete"
+      }
+    }
+  }
+}

--- a/tests/v3_api/test_rke_cluster_provisioning.py
+++ b/tests/v3_api/test_rke_cluster_provisioning.py
@@ -4,6 +4,7 @@ import pytest
 from .common import *  # NOQA
 
 K8S_VERSION = os.environ.get('RANCHER_K8S_VERSION', "")
+K8S_VERSION_UPGRADE = os.environ.get('RANCHER_K8S_VERSION_UPGRADE', "")
 DO_ACCESSKEY = os.environ.get('DO_ACCESSKEY', "None")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
@@ -505,12 +506,12 @@ def test_edit_cluster_k8s_version():
     cluster = clusters[0]
     rke_config = cluster.rancherKubernetesEngineConfig
     rke_updated_config = rke_config.copy()
-    rke_updated_config["kubernetesVersion"] = K8S_VERSION
+    rke_updated_config["kubernetesVersion"] = K8S_VERSION_UPGRADE
     cluster = client.update(cluster,
                             name=cluster.name,
                             rancherKubernetesEngineConfig=rke_updated_config)
     cluster = validate_cluster(client, cluster, intermediate_state="updating",
-                               k8s_version=K8S_VERSION)
+                               k8s_version=K8S_VERSION_UPGRADE)
 
 
 def test_delete_cluster():

--- a/tests/v3_api/test_upgrade.py
+++ b/tests/v3_api/test_upgrade.py
@@ -10,7 +10,7 @@ from .test_secrets import (
     create_secret)
 from .test_service_discovery import create_dns_record
 
-cluster_name = os.environ.get('RANCHER_CLUSTER_NAME', "")
+cluster_name = CLUSTER_NAME
 validate_prefix = os.environ.get('RANCHER_VALIDATE_RESOURCES_PREFIX', "step0")
 create_prefix = os.environ.get('RANCHER_CREATE_RESOURCES_PREFIX', "step1")
 namespace = {"p_client": None, "ns": None, "cluster": None, "project": None,


### PR DESCRIPTION
@sangeethah 

Tested:
* 12: v2.2.0 -> v2.2.1 (with k8s)
* 15: v2.2.0 -> v2.2.2-rc9 (without k8s)
* 16: v2.1.1 -> v2.2.2-rc9 (without k8s)
* With and without K8S_VERSION/UPGRADE
* EC2, DO, Azure cluster types
* Different cluster profiles (1 etcd, 1 controlplane, 1 worker; etc...)
* Required params that are not set in RANCHER_EXTRA_VARS

Not functional:
* Custom cluster (??)

Steps
* Checkout preupgrade branch
* Deploy Rancher server
* Provision a cluster
* Run pre-upgrade scripts
* Checkout postupgrade branch
* Upgrade Rancher server
* Run postupgrade scripts
* Upgrade k8s version (if supplied)
* Run postupgrade scripts (if K8S upgrade)
* Cleanup
* Test reports
* Supports EC2, DO, AZ, Custom
* Enforce required non-default env vars