### PR TITLE
Add -q flag to docker build

### DIFF
--- a/tests/v3_api/scripts/build.sh
+++ b/tests/v3_api/scripts/build.sh
@@ -15,7 +15,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" && pwd )"
 
 count=0
 while [[ 3 -gt $count ]]; do
-    docker build -f Dockerfile.v3api -t rancher-validation-tests .
+    docker build -q -f Dockerfile.v3api -t rancher-validation-tests .
     if [[ $? -eq 0 ]]; then break; fi
     count=$(($count + 1))
     echo "Repeating failed Docker build ${count} of 3..."


### PR DESCRIPTION
@sangeethah 

-q / --quiet suppresses `docker build` output. This reduces clutter in logs and makes them easier to read.