### PR TITLE
Fix pipeline checks for AWS_SSH key and name

### DIFF
--- a/tests/v3_api/Jenkinsfile
+++ b/tests/v3_api/Jenkinsfile
@@ -28,7 +28,7 @@ node {
     }
 
     stage('Configure and Build') {
-      if (AWS_SSH_PEM_KEY != '' && AWS_SSH_KEY_NAME != '') {
+      if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
         dir(".ssh") {
           def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
           writeFile file: AWS_SSH_KEY_NAME, text: decoded

--- a/tests/v3_api/Jenkinsfile_deploy_and_test
+++ b/tests/v3_api/Jenkinsfile_deploy_and_test
@@ -32,7 +32,7 @@ node {
     }
 
     stage('Configure and Build') {
-      if (AWS_SSH_PEM_KEY != '' && AWS_SSH_KEY_NAME != '') {
+      if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
         dir(".ssh") {
           def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
           writeFile file: AWS_SSH_KEY_NAME, text: decoded

--- a/tests/v3_api/Jenkinsfile_deploy_and_test_ontag
+++ b/tests/v3_api/Jenkinsfile_deploy_and_test_ontag
@@ -69,7 +69,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
         }
 
         stage('Configure and Build') {
-          if (AWS_SSH_PEM_KEY != '' && AWS_SSH_KEY_NAME != '') {
+          if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
             dir(".ssh") {
               def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
               writeFile file: AWS_SSH_KEY_NAME, text: decoded

--- a/tests/v3_api/Jenkinsfile_provisioning_tests
+++ b/tests/v3_api/Jenkinsfile_provisioning_tests
@@ -27,7 +27,7 @@ node {
     try {
       try {
         stage('Configure and Build') {
-          if (AWS_SSH_PEM_KEY != '' && AWS_SSH_KEY_NAME != '') {
+          if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
             dir(".ssh") {
               def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
               writeFile file: AWS_SSH_KEY_NAME, text: decoded

--- a/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
+++ b/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
@@ -65,7 +65,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
       try {
         try {
           stage('Configure and Build') {
-            if (AWS_SSH_PEM_KEY != '' && AWS_SSH_KEY_NAME != '') {
+            if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
               dir(".ssh") {
                 def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
                 writeFile file: AWS_SSH_KEY_NAME, text: decoded

--- a/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -81,7 +81,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
         }
 
         stage('Configure and Build') {
-          if (AWS_SSH_PEM_KEY != '' && AWS_SSH_KEY_NAME != '') {
+          if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
             dir(".ssh") {
               def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
               writeFile file: AWS_SSH_KEY_NAME, text: decoded

--- a/tests/v3_api/scripts/pipeline/Jenkinsfile_provision_and_test
+++ b/tests/v3_api/scripts/pipeline/Jenkinsfile_provision_and_test
@@ -42,7 +42,7 @@ node {
     }
 
     stage('Configure and Build') {
-      if (AWS_SSH_PEM_KEY != '' && AWS_SSH_KEY_NAME != '') {
+      if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
         dir(".ssh") {
           def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
           writeFile file: AWS_SSH_KEY_NAME, text: decoded

--- a/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade
+++ b/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade
@@ -51,7 +51,7 @@ node {
     }
 
     stage('Configure and Build') {
-      if (AWS_SSH_PEM_KEY != '' && AWS_SSH_KEY_NAME != '') {
+      if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
         dir(".ssh") {
           def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
           writeFile file: AWS_SSH_KEY_NAME, text: decoded

--- a/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade_multiple
+++ b/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade_multiple
@@ -223,7 +223,7 @@ def checkParams() {
 
 def buildContainer() {
   try {
-    if (AWS_SSH_PEM_KEY != '' && AWS_SSH_KEY_NAME != '') {
+    if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
       dir(".ssh") {
         def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
         writeFile file: AWS_SSH_KEY_NAME, text: decoded


### PR DESCRIPTION
Fix check for AWS_SSH_KEY_NAME and AWS_SSH_PEM_KEY so jobs without those params don't fail.