### PR TITLE
Make the image name unique per build

### DIFF
--- a/tests/v3_api/Jenkinsfile
+++ b/tests/v3_api/Jenkinsfile
@@ -8,7 +8,7 @@ node {
 
   def setupResultsOut = "setup-results.xml"
   def testResultsOut = "results.xml"
-  def imageName = "rancher-validation-tests"
+  def imageName = "rancher-validation-${JOB_NAME}${env.BUILD_NUMBER}"
   def testsDir = "tests/v3_api/"
 
   def branch = "master"
@@ -51,10 +51,12 @@ node {
         sh "docker cp ${testContainer}:${rootPath}${testResultsOut} ."
         step([$class: 'JUnitResultArchiver', testResults: "**/${testResultsOut}"])
         sh "docker rm -v ${testContainer}"
+        sh "docker rmi ${imageName}"
       }
     } catch(err){
       sh "docker stop ${testContainer}"
       sh "docker rm -v ${testContainer}"
+      sh "docker rmi ${imageName}"
     }
   }
 }

--- a/tests/v3_api/Jenkinsfile_deploy_and_test
+++ b/tests/v3_api/Jenkinsfile_deploy_and_test
@@ -9,7 +9,7 @@ node {
 
   def setupResultsOut = "setup-results.xml"
   def testResultsOut = "results.xml"
-  def imageName = "rancher-validation-tests"
+  def imageName = "rancher-validation-${JOB_NAME}${env.BUILD_NUMBER}"
   def testsDir = "tests/v3_api/"
 
   def envFile = ".env"
@@ -74,6 +74,7 @@ node {
 
         sh "docker rm -v ${setupContainer}"
         sh "docker rm -v ${testContainer}"
+        sh "docker rmi ${imageName}"
       }
     } catch(err){
       sh "docker stop ${setupContainer}"
@@ -81,6 +82,8 @@ node {
 
       sh "docker rm -v ${setupContainer}"
       sh "docker rm -v ${testContainer}"
+      
+      sh "docker rmi ${imageName}"
     }
   }
 }

--- a/tests/v3_api/Jenkinsfile_deploy_and_test_ontag
+++ b/tests/v3_api/Jenkinsfile_deploy_and_test_ontag
@@ -51,7 +51,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
 
       def setupResultsOut = "setup-results.xml"
       def testResultsOut = "results.xml"
-      def imageName = "rancher-validation-tests"
+      def imageName = "rancher-validation-${JOB_NAME}${env.BUILD_NUMBER}"
       def testsDir = "tests/v3_api/"
 
       def envFile = ".env"
@@ -112,6 +112,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
 
             sh "docker rm -v ${setupContainer}"
             sh "docker rm -v ${testContainer}"
+            sh "docker rmi ${imageName}"
           }
         } catch(err){
           sh "docker stop ${setupContainer}"
@@ -119,6 +120,8 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
 
           sh "docker rm -v ${setupContainer}"
           sh "docker rm -v ${testContainer}"
+
+          sh "docker rmi ${imageName}"
         }
       }
     }

--- a/tests/v3_api/Jenkinsfile_provisioning_tests
+++ b/tests/v3_api/Jenkinsfile_provisioning_tests
@@ -3,7 +3,7 @@ def deleteContainer = "${JOB_NAME}${BUILD_NUMBER}_delete"
 def deletePytestOptions = "-k test_delete_rancher_server"
 def deleteResultsOut = "delete-results.xml"
 def testsDir = "tests/v3_api/"
-def imageName = "rancher-validation-tests"
+def imageName = "rancher-validation-${JOB_NAME}${env.BUILD_NUMBER}"
 def envFile = ".env"
 def RANCHER_DEPLOYED = false
 
@@ -38,7 +38,7 @@ node {
         }
 
         stage('Deploy Rancher server') {
-          sh "docker run --name ${JOB_NAME}${BUILD_NUMBER} -t --env-file .env rancher-validation-tests /bin/bash " +
+          sh "docker run --name ${JOB_NAME}${BUILD_NUMBER} -t --env-file .env ${imageName} /bin/bash " +
              "-c \'pytest -v -s --junit-xml=setup.xml -k test_deploy_rancher_server tests/v3_api/\'"
           sh "docker cp ${JOB_NAME}${BUILD_NUMBER}:/src/rancher-validation/tests/v3_api/rancher_env.config ."
           load "rancher_env.config"
@@ -91,6 +91,7 @@ node {
       stage('Cleanup') {
         sh "docker stop ${JOB_NAME}${BUILD_NUMBER}"
         sh "docker rm -v ${JOB_NAME}${BUILD_NUMBER}"
+        sh "docker rmi ${imageName}"
       }
     }
   }

--- a/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
+++ b/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
@@ -5,7 +5,7 @@ def deleteContainer = "${JOB_NAME}${BUILD_NUMBER}_delete"
 def deletePytestOptions = "-k test_delete_rancher_server"
 def deleteResultsOut = "delete-results.xml"
 def testsDir = "tests/v3_api/"
-def imageName = "rancher-validation-tests"
+def imageName = "rancher-validation-${JOB_NAME}${env.BUILD_NUMBER}"
 def envFile = ".env"
 def RANCHER_DEPLOYED = false
 
@@ -76,7 +76,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
           }
 
           stage('Deploy Rancher server') {
-            sh "docker run --name ${JOB_NAME}${BUILD_NUMBER} -t --env-file .env rancher-validation-tests /bin/bash " +
+            sh "docker run --name ${JOB_NAME}${BUILD_NUMBER} -t --env-file .env ${imageName} /bin/bash " +
                "-c \'export RANCHER_SERVER_VERSION=${rancher_version} && pytest -v -s --junit-xml=setup.xml -k test_deploy_rancher_server tests/v3_api/\'"
             sh "docker cp ${JOB_NAME}${BUILD_NUMBER}:/src/rancher-validation/tests/v3_api/rancher_env.config ."
             load "rancher_env.config"
@@ -129,6 +129,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
         stage('Cleanup') {
           sh "docker stop ${JOB_NAME}${BUILD_NUMBER}"
           sh "docker rm -v ${JOB_NAME}${BUILD_NUMBER}"
+          sh "docker rmi ${imageName}"
         }
       }
     }

--- a/tests/v3_api/scripts/build.sh
+++ b/tests/v3_api/scripts/build.sh
@@ -15,7 +15,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" && pwd )"
 
 count=0
 while [[ 3 -gt $count ]]; do
-    docker build -q -f Dockerfile.v3api -t rancher-validation-tests .
+    docker build -q -f Dockerfile.v3api -t rancher-validation-${JOB_NAME}${BUILD_NUMBER} .
     if [[ $? -eq 0 ]]; then break; fi
     count=$(($count + 1))
     echo "Repeating failed Docker build ${count} of 3..."

--- a/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -42,6 +42,9 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
   if (rancher_version.startsWith("v2.2") || rancher_version == "master") {
     branch = "master"
   }
+  if (env.BRANCH) {
+    branch = "${BRANCH}"
+  }
   try {
     node {
       def rootPath = "/src/rancher-validation/"
@@ -59,7 +62,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
       def deleteResultsOut = "delete-results.xml"
       def deleteResultsOut2 = "delete-results-2.xml"
 
-      def imageName = "rancher-validation-tests"
+      def imageName = "rancher-validation-${JOB_NAME}${env.BUILD_NUMBER}"
       def testsDir = "tests/v3_api/"
 
       def envFile = ".env"
@@ -200,6 +203,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
             sh "docker rm -v ${deleteContainer}"
             sh "docker stop ${deleteContainer2}"
             sh "docker rm -v ${deleteContainer2}"
+            sh "docker rmi ${imageName}"
           }
         } catch(err){
           sh "docker stop ${setupContainer}"
@@ -210,6 +214,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
           sh "docker rm -v ${deleteContainer}"
           sh "docker stop ${deleteContainer2}"
           sh "docker rm -v ${deleteContainer2}"
+          sh "docker rmi ${imageName}"
         }
       }
     }

--- a/tests/v3_api/scripts/pipeline/Jenkinsfile_provision_and_test
+++ b/tests/v3_api/scripts/pipeline/Jenkinsfile_provision_and_test
@@ -9,7 +9,7 @@ node {
 
   def provisionResultsOut = "provision-results.xml"
   def testResultsOut = "api-results.xml"
-  def imageName = "rancher-validation-tests"
+  def imageName = "rancher-validation-${JOB_NAME}${env.BUILD_NUMBER}"
   def testsDir = "tests/v3_api/"
   def rancherConfig = "rancher_env.config"
 
@@ -79,6 +79,7 @@ node {
         
         sh "docker rm -v ${provisionContainer}"
         sh "docker rm -v ${testContainer}"
+        sh "docker rmi ${imageName}"
       }
     } catch(err){
       sh "docker stop ${provisionContainer}"
@@ -86,6 +87,8 @@ node {
 
       sh "docker stop ${testContainer}"
       sh "docker rm -v ${testContainer}"
+
+      sh "docker rmi ${imageName}"
 
       echo "Error: " + err
     }

--- a/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade
+++ b/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade
@@ -5,7 +5,7 @@ node {
   def containerPrefix = "${JOB_NAME}${BUILD_NUMBER}"
 
   def rancherConfig = "rancher_env.config"
-  def imageName = "rancher-validation-tests"
+  def imageName = "rancher-validation-${JOB_NAME}${env.BUILD_NUMBER}"
   def testsDir = "tests/v3_api/"
 
   def pre_branch = PREUPGRADE_BRANCH
@@ -265,6 +265,8 @@ node {
       if (RANCHER_DELETE_SERVER.toLowerCase() == "true" && buildFail == false) {
         sh "docker rm  ${containerPrefix}_delete"
       }
+
+      sh "docker rmi ${imageName}"
     }
   }
 }

--- a/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade_multiple
+++ b/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade_multiple
@@ -3,7 +3,7 @@
 rootPath = "/src/rancher-validation/"
 containerPrefix = "${JOB_NAME}${BUILD_NUMBER}"
 rancherConfig = "rancher_env.config"
-imageName = "rancher-validation-tests"
+imageName = "rancher-validation-${JOB_NAME}${env.BUILD_NUMBER}"
 testsDir = "tests/v3_api/"
 paramsConfigFile = "params_env.config"
 
@@ -169,6 +169,7 @@ node {
     }
 
     containerCleanup()
+    sh "docker rmi ${imageName}"
   }
 }
 


### PR DESCRIPTION
This will prevent jobs being run in parallel overriding the `rancher-validation-tests` image, leading to unwanted consequences (missing PEM keys, wrong branches being checked out, etc...)

To fix, we prepend the created image name with the job's name and build number, and delete after job execution.

Tested with manual cluster matrix jobs pointed to this PR. 

Verified created images are cleaned up after each job is run. 