### PR TITLE
Default to m5.large for EKS

### DIFF
--- a/tests/v3_api/test_eks_cluster.py
+++ b/tests/v3_api/test_eks_cluster.py
@@ -31,7 +31,7 @@ def get_eks_config():
     amazonConfig = {
         "accessKey": EKS_ACCESS_KEY,
         "secretKey": EKS_SECRET_KEY,
-        "instanceType": "m4.large",
+        "instanceType": "m5.large",
         "maximumNodes": 3,
         "minimumNodes": 1,
         "region": EKS_REGION,


### PR DESCRIPTION
Bring EC2 type current