### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/Dockerfile.rke
+++ b/Dockerfile.rke
@@ -14,4 +14,4 @@ RUN wget https://github.com/rancher/rke/releases/download/$RKE_VERSION/rke_linux
     mv kubectl /bin/kubectl && \
     chmod +x /bin/kubectl  && \
     cd $WORKSPACE && \
-    pip install -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt

--- a/Dockerfile.v3api
+++ b/Dockerfile.v3api
@@ -15,4 +15,4 @@ RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERS
     mv rke_linux-amd64 /bin/rke && \
     chmod +x /bin/rke && \
     cd $WORKSPACE && \
-    pip install -r requirements_v3api.txt
+    pip install --no-cache-dir -r requirements_v3api.txt

--- a/images/container-utils/Dockerfile
+++ b/images/container-utils/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update -y && \
     apt-get install -y python-pip python-dev build-essential curl dnsutils iputils-ping openssh-server net-tools && \
     mkdir /var/run/sshd && echo 'root:screencast' | chpasswd &&  \
     sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
-    pip install -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt
 
 CMD ["/app/start.sh"]


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>